### PR TITLE
Add real world xyz accelerometer data index file compression benchmark

### DIFF
--- a/tsz-compress/Cargo.toml
+++ b/tsz-compress/Cargo.toml
@@ -26,6 +26,11 @@ rand = "0.8.5"
 name = "compression"
 harness = false
 
+[[bench]]
+name = "real_world"
+harness = false
+
+
 [[bin]]
 name = "example"
 path = "bin/example.rs"

--- a/tsz-compress/benches/real_world.rs
+++ b/tsz-compress/benches/real_world.rs
@@ -1,0 +1,123 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tsz_compress::prelude::*;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    const FILE_NAME: &str = "tests/data/0001-1686168000000000-9223372037005771051-index.tsz";
+    #[derive(Default, DeltaEncodable, Decompressible, Compressible, Copy, Clone, Debug)]
+    pub(crate) struct XyzValue {
+        x: i32,
+        y: i32,
+        z: i32,
+    }
+
+    #[derive(
+        Debug,
+        Default,
+        Clone,
+        Copy,
+        PartialEq,
+        PartialOrd,
+        Eq,
+        Ord,
+        Hash,
+        DeltaEncodable,
+        Compressible,
+        Decompressible,
+    )]
+    pub struct PartitionedTimeKey {
+        pub timestamp_us: i64,
+    }
+
+    let compressed = std::fs::read(FILE_NAME).unwrap();
+
+    // Expect the header to be "TKSS"
+    let header = "_TKSS_0001_".as_bytes();
+    assert!(&compressed[0..header.len()] == header);
+    let compressed = &compressed[header.len()..];
+
+    // The next 8 bytes are the u64 byte length of the compressed data
+    let keys_byte_size = u64::from_be_bytes(compressed[..8].try_into().unwrap()) as usize;
+    let compressed = &compressed[8..];
+
+    // The next 8 bytes are the u64 bit length of the compressed data
+    let keys_bit_size = u64::from_be_bytes(compressed[..8].try_into().unwrap()) as usize;
+    assert!((keys_bit_size as usize) < compressed.len() * 8);
+    let compressed = &compressed[8..];
+
+    println!(
+        "Read Keys: {} bytes, {} bits",
+        keys_byte_size, keys_bit_size
+    );
+
+    // The next `key_byte_size` bytes are the compressed data
+    let compressed_keys = &compressed[..keys_byte_size as usize];
+    let keys_bits = BitBufferSlice::from_slice(compressed_keys);
+    let keys_bits = keys_bits.split_at(keys_bit_size as usize).0;
+    let mut keys_decompressor = Decompressor::new(keys_bits);
+    let compressed = &compressed[keys_byte_size as usize..];
+
+    // Expect the header to be "TKSS"
+    let header = "_TKSS_0001_".as_bytes();
+    assert!(&compressed[0..header.len()] == header);
+    let compressed = &compressed[header.len()..];
+
+    // The next 8 bytes are the u64 byte length of the compressed data
+    let values_byte_size = u64::from_be_bytes(compressed[..8].try_into().unwrap()) as usize;
+    assert!((values_byte_size + 8) <= compressed.len());
+    let compressed = &compressed[8..];
+
+    let values_bit_size = u64::from_be_bytes(compressed[..8].try_into().unwrap()) as usize;
+    let compressed = &compressed[8..];
+
+    assert!(values_byte_size == compressed.len());
+    println!(
+        "Read Values: {} bytes, {} bits",
+        values_byte_size, values_bit_size
+    );
+
+    // The next `value_byte_size` bytes are the compressed data
+    let compressed_values = &compressed[..values_byte_size as usize];
+    let values_bits = BitBufferSlice::from_slice(compressed_values);
+    let values_bits = values_bits.split_at(values_bit_size as usize).0;
+    let mut values_decompressor = Decompressor::new(values_bits);
+
+    println!(
+        "Decompressing {} bytes of keys and {} bytes of values",
+        keys_byte_size, values_byte_size
+    );
+
+    let decompress_iter = keys_decompressor
+        .decompress::<PartitionedTimeKey>()
+        .zip(values_decompressor.decompress::<XyzValue>())
+        .into_iter()
+        .map(|(k, v)| (k.unwrap(), v.unwrap()));
+
+    let mut infinite_iter = std::iter::repeat(&decompress_iter);
+    c.bench_function("decompress xyz 1k", |b| {
+        b.iter(|| {
+            black_box(for _ in 0..100_000 {
+                let foo = infinite_iter.next().unwrap();
+                black_box(foo);
+            })
+        })
+    });
+    c.bench_function("decompress xyz 1M", |b| {
+        b.iter(|| {
+            black_box(for _ in 0..1_000_000 {
+                let foo = infinite_iter.next().unwrap();
+                black_box(foo);
+            })
+        })
+    });
+    c.bench_function("decompress xyz 10M", |b| {
+        b.iter(|| {
+            black_box(for _ in 0..10_000_000 {
+                let foo = infinite_iter.next().unwrap();
+                black_box(foo);
+            })
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/tsz-compress/src/compress.rs
+++ b/tsz-compress/src/compress.rs
@@ -184,6 +184,7 @@ impl<'de> Decompressor<'de> {
 ///
 /// An iterator over the decompressed data.
 ///
+#[derive(Clone)]
 pub struct DecompressIter<'a, T> {
     input: &'a BitBufferSlice,
     finished: bool,


### PR DESCRIPTION
```
Read Keys: 7310002 bytes, 58480016 bits
Read Values: 76351458 bytes, 610811659 bits
Decompressing 7310002 bytes of keys and 76351458 bytes of values
decompress xyz 10k      time:   [251.89 µs 254.01 µs 256.07 µs]
                        change: [-0.7956% +0.0940% +0.9509%] (p = 0.83 > 0.05)
                        No change in performance detected.

decompress xyz 100k     time:   [2.5161 ms 2.5329 ms 2.5496 ms]
                        change: [-1.2043% -0.2681% +0.6166%] (p = 0.57 > 0.05)
                        No change in performance detected.

decompress xyz 1M       time:   [25.349 ms 25.515 ms 25.677 ms]
                        change: [-1.0376% -0.1140% +0.8877%] (p = 0.81 > 0.05)
                        No change in performance detected.

compress xyz 10k        time:   [678.08 µs 692.03 µs 705.24 µs]
                        change: [-2.0782% +0.0086% +2.1743%] (p = 0.99 > 0.05)
                        No change in performance detected.

compress xyz 100k       time:   [6.7257 ms 6.8494 ms 6.9737 ms]
                        change: [-2.0420% +0.4081% +3.0838%] (p = 0.75 > 0.05)
                        No change in performance detected.

Benchmarking compress xyz 1M: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, or reduce sample count to 70.
compress xyz 1M         time:   [68.213 ms 69.448 ms 70.708 ms]
                        change: [-2.0923% +0.2392% +2.7944%] (p = 0.86 > 0.05)
                        No change in performance detected.

```

The row size is (8 + 2 + 2 + 2 = 14) bytes per row with decompression at 26ms and compression at 70ms per 1m rows.

Decompression: 510MBps
Compression: 190MBps