### PR TITLE
Add CompressV2 proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -142,7 +142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -256,6 +256,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -378,18 +387,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -521,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -566,6 +575,7 @@ dependencies = [
 name = "tsz-macro"
 version = "1.1.0"
 dependencies = [
+ "itertools 0.11.0",
  "quote",
  "syn",
 ]

--- a/tsz-compress/src/lib.rs
+++ b/tsz-compress/src/lib.rs
@@ -176,7 +176,7 @@ pub mod uvlq;
 
 pub mod prelude {
     pub use crate::compress::*;
-    pub use crate::v2::queue::*;
+    pub use crate::v2::*;
     pub use bitvec::prelude as bv;
 }
 

--- a/tsz-compress/src/lib.rs
+++ b/tsz-compress/src/lib.rs
@@ -176,6 +176,7 @@ pub mod uvlq;
 
 pub mod prelude {
     pub use crate::compress::*;
+    pub use crate::v2::queue::*;
     pub use bitvec::prelude as bv;
 }
 

--- a/tsz-compress/src/v2/mod.rs
+++ b/tsz-compress/src/v2/mod.rs
@@ -1,1 +1,84 @@
+use crate::prelude::*;
+
 pub mod queue;
+pub use queue::*;
+
+///
+/// Pop N values from the queue and emit them to the bit buffer.
+/// N may be 0 if flush is false.
+///
+/// Returns the number of elements popped from the queue.
+///
+#[allow(unused)]
+pub fn emit_bits<T>(q: &mut CompressionQueue<T, 10>, out: &mut BitBuffer, flush: bool) -> usize {
+    // todo
+    0
+}
+
+///
+/// High-level interface for compression.
+///
+pub trait TszCompressV2 {
+    /// The type of the row to compress.
+    type T: Copy;
+
+    ///
+    /// Lazily compress a row.
+    ///
+    fn compress(&mut self, row: Self::T);
+
+    ///
+    /// The number of bits that have been compressed.
+    /// This is an estimate, as the last few samples may have been emitted are estimated.
+    ///
+    fn len(&self) -> usize;
+
+    ///
+    /// Return an estimate of bits per column value as the number of
+    /// compressed bits / count of column values compressed / columns per row.
+    ///
+    fn bit_rate(&self) -> usize;
+
+    ///
+    /// Finish compression and return the compressed data.
+    ///
+    fn finish(self) -> BitBuffer;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_impl_compress() {
+        #[derive(Copy, Clone)]
+        struct TestRow {
+            a: i32,
+            b: i64,
+        }
+        struct CompressorImpl {
+            a_queue: CompressionQueue<i32, 10>,
+            b_queue: CompressionQueue<i64, 10>,
+        }
+
+        impl TszCompressV2 for CompressorImpl {
+            type T = TestRow;
+            fn compress(&mut self, row: TestRow) {
+                self.a_queue.push(row.a);
+                self.b_queue.push(row.b);
+            }
+
+            fn len(&self) -> usize {
+                self.a_queue.len() + self.b_queue.len()
+            }
+
+            fn bit_rate(&self) -> usize {
+                0
+            }
+
+            fn finish(self) -> BitBuffer {
+                BitBuffer::new()
+            }
+        }
+    }
+}

--- a/tsz-compress/tests/compress-v2.rs
+++ b/tsz-compress/tests/compress-v2.rs
@@ -13,6 +13,7 @@ mod tests {
             a: i8,
             b: i16,
             c: i32,
+            d: i64,
         }
     }
 }

--- a/tsz-compress/tests/compress-v2.rs
+++ b/tsz-compress/tests/compress-v2.rs
@@ -1,0 +1,18 @@
+#![allow(unused)]
+use tsz_compress::prelude::*;
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn can_expand_v2() {
+        #[derive(Copy, Clone, CompressV2)]
+        struct TestRow {
+            a: i8,
+            b: i16,
+            c: i32,
+        }
+    }
+}

--- a/tsz-macro/Cargo.toml
+++ b/tsz-macro/Cargo.toml
@@ -14,5 +14,6 @@ version = { workspace = true }
 proc-macro = true
 
 [dependencies]
-quote = "1.0.26"
-syn = { version = "2.0.10", features = ["full"] }
+quote = "1.0.33"
+syn = { version = "2.0.38", features = ["full", "extra-traits"] }
+itertools = "0.11.0"


### PR DESCRIPTION
Initial expansion and integration test for new compress proc macro. The "extra-traits" feature doesn't need to be there long term.

```
jacobtrueb@Jacobs-Mac-Studio tsz % cargo watch -x 'expand --package tsz-compress --test compress-v2'      
[Running 'cargo expand --package tsz-compress --test compress-v2']
   Compiling tsz-macro v1.1.0 (/Users/jacobtrueb/Desktop/workspace/tsz/tsz-macro)
    Checking tsz-compress v1.1.0 (/Users/jacobtrueb/Desktop/workspace/tsz/tsz-compress)
ident: Ident { ident: "TestRow", span: #0 bytes(189..196) }
    Finished dev [unoptimized + debuginfo] target(s) in 0.65s

#![feature(prelude_import)]
#![allow(unused)]
#[prelude_import]
use std::prelude::rust_2021::*;
#[macro_use]
extern crate std;
use tsz_compress::prelude::*;
#[cfg(test)]
mod tests {
    use super::*;
    extern crate test;
    #[cfg(test)]
    #[rustc_test_marker = "tests::can_expand_v2"]
    pub const can_expand_v2: test::TestDescAndFn = test::TestDescAndFn {
        desc: test::TestDesc {
            name: test::StaticTestName("tests::can_expand_v2"),
            ignore: false,
            ignore_message: ::core::option::Option::None,
            source_file: "tsz-compress/tests/compress-v2.rs",
            start_line: 10usize,
            start_col: 8usize,
            end_line: 10usize,
            end_col: 21usize,
            compile_fail: false,
            no_run: false,
            should_panic: test::ShouldPanic::No,
            test_type: test::TestType::IntegrationTest,
        },
        testfn: test::StaticTestFn(|| test::assert_test_result(can_expand_v2())),
    };
    fn can_expand_v2() {
        struct TestRow {
            a: i8,
            b: i16,
            c: i32,
        }
        #[automatically_derived]
        impl ::core::marker::Copy for TestRow {}
        #[automatically_derived]
        impl ::core::clone::Clone for TestRow {
            #[inline]
            fn clone(&self) -> TestRow {
                let _: ::core::clone::AssertParamIsClone<i8>;
                let _: ::core::clone::AssertParamIsClone<i16>;
                let _: ::core::clone::AssertParamIsClone<i32>;
                *self
            }
        }
        pub struct TestRowCompressor {
            _phantom: ::core::marker::PhantomData<TestRow>,
            a_compressor: ::tsz_compress::prelude::CompressionQueue<i8, 10>,
            b_compressor: ::tsz_compress::prelude::CompressionQueue<i16, 10>,
            c_compressor: ::tsz_compress::prelude::CompressionQueue<i32, 10>,
        }
    }
}
#[rustc_main]
#[no_coverage]
pub fn main() -> () {
    extern crate test;
    test::test_main_static(&[&can_expand_v2])
}
[Finished running. Exit status: 0]
```