### PR TITLE
Fix decoding with additional error messages

### DIFF
--- a/tsz-compress/src/v2/mod.rs
+++ b/tsz-compress/src/v2/mod.rs
@@ -9,8 +9,26 @@ pub use queue::*;
 
 #[derive(Debug)]
 pub enum CodingError {
+    /// There is not enough data to decode a single value.
+    Empty,
+    /// There were not enough bits to finish decoding an expected value.
     NotEnoughBits,
+    /// There were bits that indicated an invalid value.
     InvalidBits,
+    /// The first column tag was invalid.
+    InvalidInitialColumnTag,
+    /// A non-first column tag was invalid.
+    InvalidColumnTag,
+    /// The number of rows decoded did not match the expected number of rows.
+    ColumnLengthMismatch(ColumnLengths),
+    /// The number of rows to decode cannot be valid
+    InvalidRowCount(usize),
+}
+
+#[derive(Debug)]
+pub struct ColumnLengths {
+    pub expected_rows: usize,
+    pub column_lengths: ::alloc::vec::Vec<usize>,
 }
 
 ///

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -975,7 +975,7 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
 
                         // Read the row count, accepting a reservation up to 2^32 rows
                         // SAFETY: The decompressor will reserve at most 2^32 rows, but there may be more if overflow occurs.
-                        let rows = read_full_i32(bytes) as isize;
+                        let rows = read_full_i32(bytes) as u32;
                         let bytes = &bytes[core::mem::size_of::<i32>()..];
 
                         // At best we can emit 3 bits per row not counting any metadata for one column
@@ -985,8 +985,8 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
 
                         // Reserve space for the rows if there is enough remaining capacity
                         #(
-                            let remaining = (self.#col_vec_idents.capacity() - self.#col_vec_idents.len()) as isize ;
-                            let reservation = rows - remaining;
+                            let remaining = (self.#col_vec_idents.capacity() - self.#col_vec_idents.len()) as isize;
+                            let reservation = rows as isize - remaining;
                             if reservation > 0 {
                                 self.#col_vec_idents.reserve(reservation as usize);
                             }

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -856,8 +856,17 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                             });
                         )*
 
+                        // Write the number of rows as a 32-bit integer
+                        // The decompressor will read this value and reserve space for the rows
+                        // SAFETY: The number of rows may be more than 2^32, but the decompressor will
+                        //         reserve at most 2^32 rows.
+                        let mut rows = ::tsz_compress::prelude::halfvec::HalfVec::new(8);
+                        write_i32_bits(&mut rows, self.rows as u32 as i32);
+
                         // Create an iterator over the words to be written
+                        let rows = Some(rows);
                         let words = [
+                            rows.as_ref().into_iter(),
                             #(
                                 self.#col_delta_buf_idents.as_ref().into_iter(),
                                 self.#col_delta_delta_buf_idents.as_ref().into_iter(),
@@ -959,13 +968,37 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
 
                     /// Decompress tsz-compressed bytes, extending the columns with the decompressed values.
                     fn decompress(&mut self, bytes: &[u8]) -> Result<(), CodingError> {
-                        // Iterate over the bits
-                        let mut iter = HalfIter::new(&bytes);
+                        // Require at least the row count and 1 column
+                        if bytes.len() < 9 {
+                            return Err(CodingError::Empty);
+                        }
 
+                        // Read the row count, accepting a reservation up to 2^32 rows
+                        // SAFETY: The decompressor will reserve at most 2^32 rows, but there may be more if overflow occurs.
+                        let rows = read_full_i32(bytes) as isize;
+                        let bytes = &bytes[core::mem::size_of::<i32>()..];
+
+                        // At best we can emit 3 bits per row not counting any metadata for one column
+                        if rows as usize > bytes.len() * 8 / 3 {
+                            return Err(CodingError::InvalidRowCount(rows as usize));
+                        }
+
+                        // Reserve space for the rows if there is enough remaining capacity
+                        #(
+                            let remaining = (self.#col_vec_idents.capacity() - self.#col_vec_idents.len()) as isize ;
+                            let reservation = rows - remaining;
+                            if reservation > 0 {
+                                self.#col_vec_idents.reserve(reservation as usize);
+                            }
+                        )*
+
+                        // Iterate over the bits
+                        let mut iter = HalfIter::new(bytes);
 
                         // Expect a 1001 tag indicating the start of a new column
                         if iter.next() != Some(0b1001) {
-                            return Err(CodingError::InvalidBits);
+                            #( self.#col_vec_idents.clear(); )*
+                            return Err(CodingError::InvalidInitialColumnTag);
                         }
 
                         // Read the column bytes into a vector one after the other
@@ -974,14 +1007,15 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
                         // Pad nibbles to byte-alignment
                         match iter.next() {
                             Some(0b1001) => (),
-                            Some(_) => return Err(CodingError::InvalidBits),
+                            Some(_) => return Err(CodingError::InvalidColumnTag),
                             None => (),
                         }
 
                         // Make sure all the columns are the same length
                         let elems = [ #( self.#col_vec_idents.len(), )* ];
                         if !elems.iter().all(|elem| *elem == elems[0]) {
-                            return Err(CodingError::InvalidBits);
+                            #( self.#col_vec_idents.clear(); )*
+                            return Err(CodingError::ColumnLengthMismatch(ColumnLengths { expected_rows: rows as usize, column_lengths: elems.to_vec() }));
                         }
 
                         Ok(())


### PR DESCRIPTION
This adds error messages to help identify causes for failed decoding. There was a mismatch on the 4 samples of 8 bits and 8 samples of 4 bits. Adding a row reservation header of 32 bits helps identify the expected number of rows and make capacity adjustment prior to decoding.