### PR TITLE
Hold zigzag bits in CompressionQueue

### DIFF
--- a/tsz-compress/src/v2/encode.rs
+++ b/tsz-compress/src/v2/encode.rs
@@ -6,18 +6,19 @@ use crate::prelude::*;
 
 use super::halfvec::{HalfVec, HalfWord};
 
-trait Bits: PrimInt + Binary {
+pub trait Bits: PrimInt + Binary {
     const BITS: usize;
 
     /// Language limitations prevent us from writing simple math expressions
     /// ((self << 1) ^ (self >> Self::BITS - 1)) as u32
-    fn zigzag_bits(self) -> u32;
+    fn zigzag(self) -> u32;
 
-    fn zigzag_bit_masked(self, mask: u32) -> u32 {
-        // Mask bottom bits
-        let r = self.zigzag_bits() & mask;
-        // println!("r: {:b}", r);
-        r
+    /// Return the zigzag encoding and number of bits required to represent the value
+    #[inline(always)]
+    fn zigzag_bits(self) -> (u32, usize) {
+        let zbits = self.zigzag();
+        let leading = zbits.leading_zeros() as usize;
+        (zbits, Self::BITS - leading)
     }
 }
 
@@ -25,7 +26,7 @@ impl Bits for i8 {
     const BITS: usize = 8;
     /// Language limitations prevent us from writing simple math expressions
     #[inline(always)]
-    fn zigzag_bits(self) -> u32 {
+    fn zigzag(self) -> u32 {
         ((self << 1) ^ (self >> Self::BITS - 1)) as u32
     }
 }
@@ -34,7 +35,7 @@ impl Bits for i16 {
     const BITS: usize = 16;
     /// Language limitations prevent us from writing simple math expressions
     #[inline(always)]
-    fn zigzag_bits(self) -> u32 {
+    fn zigzag(self) -> u32 {
         ((self << 1) ^ (self >> Self::BITS - 1)) as u32
     }
 }
@@ -43,211 +44,144 @@ impl Bits for i32 {
     const BITS: usize = 32;
     /// Language limitations prevent us from writing simple math expressions
     #[inline(always)]
-    fn zigzag_bits(self) -> u32 {
+    fn zigzag(self) -> u32 {
         ((self << 1) ^ (self >> Self::BITS - 1)) as u32
     }
 }
 
 #[inline(always)]
-unsafe fn push_three_bits<T: PrimInt + Bits>(q: &mut CompressionQueue<T, 10>, buf: &mut HalfVec) {
+fn push_three_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 10;
     const N1: usize = N - 1;
     buf.push(HalfWord::Half(0b1111));
     let mut word: u32 = 0;
-    let mask = 0b111_u32;
-    let values = q.pop_n::<N>().unwrap_unchecked();
+    let values = q.pop_n::<N>();
     for i in 0..N1 {
-        word |= values[i].zigzag_bit_masked(mask);
+        word |= values[i];
         word <<= 3;
     }
-    word |= values[N1].zigzag_bit_masked(mask);
+    word |= values[N1];
     buf.push(HalfWord::Full(word));
 }
 
-// #[inline(always)]
-// unsafe fn push_four_bits<T: PrimInt + Bits>(q: &mut CompressionQueue<T, 10>, buf: &mut HalfVec) {
-//     const N: usize = 8;
-//     const N1: usize = N - 1;
-//     buf.push(HalfWord::Half(0b1110));
-//     let mut word: u32 = 0;
-//     let mask = 0b1111_u32;
-//     let values = q.pop_n::<N>().unwrap_unchecked();
-//     for i in 0..N1 {
-//         word |= values[i].zigzag_bit_masked(mask);
-//         word <<= 4;
-//     }
-//     word |= values[N1].zigzag_bit_masked(mask);
-//     buf.push(HalfWord::Full(word));
-// }
-
 #[inline(always)]
-unsafe fn push_six_bits<T: PrimInt + Bits>(q: &mut CompressionQueue<T, 10>, buf: &mut HalfVec) {
+fn push_six_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 5;
     const N1: usize = N - 1;
     buf.push(HalfWord::Half(0b1110));
     let mut word: u32 = 0;
-    let mask = 0b11_1111_u32;
-    let values = q.pop_n::<N>().unwrap_unchecked();
+    let values = q.pop_n::<N>();
     for i in 0..N1 {
-        word |= values[i].zigzag_bit_masked(mask);
+        word |= values[i];
         word <<= 6;
     }
-    word |= values[N1].zigzag_bit_masked(mask);
+    word |= values[N1];
     buf.push(HalfWord::Full(word));
 }
 
 #[inline(always)]
-unsafe fn push_eight_bits<T: PrimInt + Bits>(q: &mut CompressionQueue<T, 10>, buf: &mut HalfVec) {
+fn push_eight_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 4;
     const N1: usize = N - 1;
     buf.push(HalfWord::Half(0b1100));
     let mut word: u32 = 0;
-    let mask = 0b1111_1111_u32;
-    let values = q.pop_n::<N>().unwrap_unchecked();
+    let values = q.pop_n::<N>();
     for i in 0..N1 {
-        word |= values[i].zigzag_bit_masked(mask);
+        word |= values[i];
         word <<= 8;
     }
-    word |= values[N1].zigzag_bit_masked(mask);
+    word |= values[N1];
     buf.push(HalfWord::Full(word));
 }
 
 #[inline(always)]
-unsafe fn push_ten_bits<T: PrimInt + Bits>(q: &mut CompressionQueue<T, 10>, buf: &mut HalfVec) {
+fn push_ten_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 3;
     const N1: usize = N - 1;
     buf.push(HalfWord::Half(0b1010));
     let mut word: u32 = 0b00 << 10;
-    let mask = 0b11_1111_1111_u32;
-    let values = q.pop_n::<N>().unwrap_unchecked();
+    let values = q.pop_n::<N>();
     for i in 0..N1 {
-        word |= values[i].zigzag_bit_masked(mask);
+        word |= values[i];
         word <<= 10;
     }
-    word |= values[N1].zigzag_bit_masked(mask);
+    word |= values[N1];
     buf.push(HalfWord::Full(word));
 }
 
 #[inline(always)]
-unsafe fn push_sixteen_bits<T: PrimInt + Bits>(q: &mut CompressionQueue<T, 10>, buf: &mut HalfVec) {
+fn push_sixteen_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 2;
     const N1: usize = N - 1;
     buf.push(HalfWord::Half(0b1000));
     let mut word: u32 = 0b00 << 10;
-    let mask = 0xffffu32;
-    let values = q.pop_n::<N>().unwrap_unchecked();
+    let values = q.pop_n::<N>();
     for i in 0..N1 {
-        word |= values[i].zigzag_bit_masked(mask);
+        word |= values[i];
         word <<= 16;
     }
-    word |= values[N1].zigzag_bit_masked(mask);
+    word |= values[N1];
     buf.push(HalfWord::Full(word));
 }
 
 #[inline(always)]
-unsafe fn push_thirty_two_bits<T: PrimInt + Bits>(
-    q: &mut CompressionQueue<T, 10>,
-    buf: &mut HalfVec,
-) {
+unsafe fn push_thirty_two_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     buf.push(HalfWord::Half(0b1011));
     let value = q.pop().unwrap_unchecked();
-    let word = value.zigzag_bits();
-    buf.push(HalfWord::Full(word));
+    buf.push(HalfWord::Full(value));
 }
 
 // Todo: How can we implement this?
 // #[inline(always)]
 // unsafe fn push_sixty_four_bits<T: PrimInt + Bits>();
 
-pub trait EmitDeltaBits<T> {
+pub trait EmitDeltaBits {
     /// Emits bits according to the most efficient case of Delta Compression.
     /// Returns the number of elements popped from the queue.
-    fn emit_delta_bits(&mut self, out: &mut HalfVec, flush: bool) -> usize;
+    fn emit_delta_bits(&mut self, out: &mut HalfVec) -> usize;
+    fn flush_delta_bits(&mut self, out: &mut HalfVec) -> usize;
 }
 
-impl EmitDeltaBits<i32> for CompressionQueue<i32, 10> {
-    #[allow(unused)]
-    fn emit_delta_bits(&mut self, out: &mut HalfVec, flush: bool) -> usize {
-        let queue_length = self.len();
+impl EmitDeltaBits for CompressionQueue<10> {
+    #[inline(always)]
+    fn emit_delta_bits(&mut self, out: &mut HalfVec) -> usize {
         let mut fits = [true; 6];
 
-        // Check flush conditions
-        if flush {
-            // Can not emit with any case of delta compression if queue is empty
-            if self.is_empty() {
-                return 0;
-            }
-
-            // Can not emit with case v of delta compression if number of samples < 10
-            if self.len() < 10 {
-                fits[0] = false;
-            }
-
-            // Can not emit with case iv of delta compression if number of samples < 5.
-            if self.len() < 5 {
-                fits[1] = false;
-            }
-
-            // Can not emit with case iii of delta compression if number of samples < 4
-            if self.len() < 4 {
-                fits[2] = false;
-            }
-
-            // Can not emit with case ii of delta compression if number of samples < 3
-            if self.len() < 3 {
-                fits[3] = false;
-            }
-
-            // Can not emit with case ii of delta compression if number of samples < 2
-            if self.len() < 2 {
+        // Check if the values will fit in the cases
+        let values = self.peak_bitcounts::<10>();
+        for (index, bits_required) in values.into_iter().enumerate() {
+            if (index < 2) & (bits_required > 16) {
                 fits[4] = false;
             }
-        }
-
-        for (index, value) in self.iter().enumerate() {
-            if (index < 2 && !(-32768..=32767).contains(&value)) {
-                fits[..=4].fill(false);
-                break;
-            }
-            if (index < 3 && !(-512..=511).contains(&value)) {
+            if (index < 3) & (bits_required > 10) {
                 fits[3] = false;
             }
-            if (index < 4 && !(-128..=127).contains(&value)) {
+            if (index < 4) & (bits_required > 8) {
                 fits[2] = false;
             }
-            if (index < 5 && !(-32..=31).contains(&value)) {
+            if (index < 5) & (bits_required > 6) {
                 fits[1] = false;
             }
-            if (index < 10 && !(-4..=3).contains(&value)) {
+            if (index < 10) & (bits_required > 3) {
                 fits[0] = false;
             }
         }
 
         // Emit according to priority of cases
         if fits[0] {
-            unsafe {
-                push_three_bits(self, out);
-            }
+            push_three_bits(self, out);
             return 10;
         } else if fits[1] {
-            unsafe {
-                push_six_bits(self, out);
-            }
+            push_six_bits(self, out);
             return 5;
         } else if fits[2] {
-            unsafe {
-                push_eight_bits(self, out);
-            }
+            push_eight_bits(self, out);
             return 4;
         } else if fits[3] {
-            unsafe {
-                push_ten_bits(self, out);
-            }
+            push_ten_bits(self, out);
             return 3;
         } else if fits[4] {
-            unsafe {
-                push_sixteen_bits(self, out);
-            }
+            push_sixteen_bits(self, out);
             return 2;
         } else if fits[5] {
             unsafe {
@@ -257,176 +191,76 @@ impl EmitDeltaBits<i32> for CompressionQueue<i32, 10> {
         }
         0
     }
-}
 
-impl EmitDeltaBits<i16> for CompressionQueue<i16, 10> {
-    #[allow(unused)]
-    fn emit_delta_bits(&mut self, out: &mut HalfVec, flush: bool) -> usize {
-        let queue_length = self.len();
+    #[inline(always)]
+    fn flush_delta_bits(&mut self, out: &mut HalfVec) -> usize {
         let mut fits = [true; 6];
 
-        // Check flush conditions
-        if flush {
-            // Can not emit with any case of delta compression if queue is empty
-            if self.is_empty() {
-                return 0;
-            }
-
-            // Can not emit with case v of delta compression if number of samples < 10
-            if self.len() < 10 {
-                fits[0] = false;
-            }
-
-            // Can not emit with case iv of delta compression if number of samples < 5.
-            if self.len() < 5 {
-                fits[1] = false;
-            }
-
-            // Can not emit with case iii of delta compression if number of samples < 4
-            if self.len() < 4 {
-                fits[2] = false;
-            }
-
-            // Can not emit with case ii of delta compression if number of samples < 3
-            if self.len() < 3 {
-                fits[3] = false;
-            }
-
-            // Can not emit with case ii of delta compression if number of samples < 2
-            if self.len() < 2 {
-                fits[4] = false;
-            }
+        // Can not emit with any case of delta compression if queue is empty
+        if self.is_empty() {
+            return 0;
         }
 
-        for (index, value) in self.iter().enumerate() {
-            // println!("value: {}", value);
-            if (index < 3 && !(-512..=511).contains(&value)) {
-                fits[..=3].fill(false);
-                break;
+        // Can not emit with case v of delta compression if number of samples < 10
+        if self.len() < 10 {
+            fits[0] = false;
+        }
+
+        // Can not emit with case iv of delta compression if number of samples < 5.
+        if self.len() < 5 {
+            fits[1] = false;
+        }
+
+        // Can not emit with case iii of delta compression if number of samples < 4
+        if self.len() < 4 {
+            fits[2] = false;
+        }
+
+        // Can not emit with case ii of delta compression if number of samples < 3
+        if self.len() < 3 {
+            fits[3] = false;
+        }
+
+        // Can not emit with case ii of delta compression if number of samples < 2
+        if self.len() < 2 {
+            fits[4] = false;
+        }
+
+        // Check if the values will fit in the cases
+        let values = self.peak_bitcounts::<10>();
+        for (index, bits_required) in values.into_iter().enumerate() {
+            if (index < 2) & (bits_required > 16) {
+                fits[4] = false;
             }
-            if (index < 4 && !(-128..=127).contains(&value)) {
+            if (index < 3) & (bits_required > 10) {
+                fits[3] = false;
+            }
+            if (index < 4) & (bits_required > 8) {
                 fits[2] = false;
             }
-            if (index < 5 && !(-32..=31).contains(&value)) {
+            if (index < 5) & (bits_required > 6) {
                 fits[1] = false;
             }
-            if (index < 10 && !(-4..=3).contains(&value)) {
+            if (index < 10) & (bits_required > 3) {
                 fits[0] = false;
             }
         }
 
         // Emit according to priority of cases
         if fits[0] {
-            unsafe {
-                push_three_bits(self, out);
-            }
+            push_three_bits(self, out);
             return 10;
         } else if fits[1] {
-            unsafe {
-                push_six_bits(self, out);
-            }
+            push_six_bits(self, out);
             return 5;
         } else if fits[2] {
-            unsafe {
-                push_eight_bits(self, out);
-            }
+            push_eight_bits(self, out);
             return 4;
         } else if fits[3] {
-            unsafe {
-                push_ten_bits(self, out);
-            }
+            push_ten_bits(self, out);
             return 3;
         } else if fits[4] {
-            unsafe {
-                push_sixteen_bits(self, out);
-            }
-            return 2;
-        } else if fits[5] {
-            unsafe {
-                push_thirty_two_bits(self, out);
-            }
-            return 1;
-        }
-        0
-    }
-}
-
-impl EmitDeltaBits<i8> for CompressionQueue<i8, 10> {
-    #[allow(unused)]
-    fn emit_delta_bits(&mut self, out: &mut HalfVec, flush: bool) -> usize {
-        let queue_length = self.len();
-        let mut fits = [true; 6];
-
-        // Check flush conditions
-        if flush {
-            // Can not emit with any case of delta compression if queue is empty
-            if self.is_empty() {
-                return 0;
-            }
-
-            // Can not emit with case v of delta compression if number of samples < 10
-            if self.len() < 10 {
-                fits[0] = false;
-            }
-
-            // Can not emit with case iv of delta compression if number of samples < 5.
-            if self.len() < 5 {
-                fits[1] = false;
-            }
-
-            // Can not emit with case iii of delta compression if number of samples < 4
-            if self.len() < 4 {
-                fits[2] = false;
-            }
-
-            // Can not emit with case ii of delta compression if number of samples < 3
-            if self.len() < 3 {
-                fits[3] = false;
-            }
-
-            // Can not emit with case ii of delta compression if number of samples < 2
-            if self.len() < 2 {
-                fits[4] = false;
-            }
-        }
-
-        for (index, value) in self.iter().enumerate() {
-            if (index < 4 && !(-128..=127).contains(&value)) {
-                fits[2] = false;
-            }
-            if (index < 5 && !(-32..=31).contains(&value)) {
-                fits[1] = false;
-            }
-            if (index < 10 && !(-4..=3).contains(&value)) {
-                fits[0] = false;
-            }
-        }
-
-        // Emit according to priority of cases
-        if fits[0] {
-            unsafe {
-                push_three_bits(self, out);
-            }
-            return 10;
-        } else if fits[1] {
-            unsafe {
-                push_six_bits(self, out);
-            }
-            return 5;
-        } else if fits[2] {
-            unsafe {
-                push_eight_bits(self, out);
-            }
-            return 4;
-        } else if fits[3] {
-            unsafe {
-                push_ten_bits(self, out);
-            }
-            return 3;
-        } else if fits[4] {
-            unsafe {
-                push_sixteen_bits(self, out);
-            }
+            push_sixteen_bits(self, out);
             return 2;
         } else if fits[5] {
             unsafe {
@@ -439,160 +273,60 @@ impl EmitDeltaBits<i8> for CompressionQueue<i8, 10> {
 }
 
 // Delta-Delta Encoding
-pub trait EmitDeltaDeltaBits<T> {
+pub trait EmitDeltaDeltaBits {
     /// Emits bits according to the most efficient case of Delta Compression.
     /// Returns the number of elements popped from the queue.
     fn emit_delta_delta_bits(&mut self, out: &mut HalfVec) -> usize;
 }
 
-fn emit_popped_values32<const N: usize>(values: &[i32; N], out: &mut HalfVec) {
-    for value in values {
-        match value {
+fn emit_popped_values<const N: usize>(
+    bitcounts: &[usize; N],
+    values: &[u32; N],
+    out: &mut HalfVec,
+) {
+    for (bits, value) in bitcounts.into_iter().zip(values.into_iter()) {
+        match bits {
             0 => out.push(HalfWord::Half(0b0000)),
-            -1 => out.push(HalfWord::Half(0b0001)),
-            -16..=15 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111) as u8;
+            // -1 => out.push(HalfWord::Half(0b0001)),
+            1..=5 => {
+                let zigzag = (value & 0b1_1111) as u8;
                 out.push(HalfWord::Byte(0b0010_0000 | zigzag));
             }
-            -256..=255 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111_1111) as u16;
+            6..=9 => {
+                let zigzag = (value & 0b1_1111_1111) as u16;
                 out.push(HalfWord::Half(0b0100 | (zigzag >> 8) as u8));
                 out.push(HalfWord::Byte(zigzag as u8));
             }
-            -32678..=32767 => {
-                let zigzag = value.zigzag_bit_masked(0b1111_1111_1111_1111) as u16;
+            10..=16 => {
+                let zigzag = (value & 0b1111_1111_1111_1111) as u16;
                 out.push(HalfWord::Half(0b0110));
                 out.push(HalfWord::Byte((zigzag >> 8) as u8));
                 out.push(HalfWord::Byte(zigzag as u8));
             }
             _ => {
-                let zigzag = value.zigzag_bits();
                 out.push(HalfWord::Half(0b0111));
-                out.push(HalfWord::Full(zigzag));
+                out.push(HalfWord::Full(*value));
             }
         }
     }
 }
 
-fn emit_popped_values32_q(q: &mut CompressionQueue<i32, 2>, out: &mut HalfVec) {
-    while !q.is_empty() {
-        let value = unsafe { q.pop().unwrap_unchecked() };
-        match value {
-            0 => out.push(HalfWord::Half(0b0000)),
-            -1 => out.push(HalfWord::Half(0b0001)),
-            -16..=15 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111) as u8;
-                out.push(HalfWord::Byte(0b0010_0000 | zigzag));
-            }
-            -256..=255 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111_1111) as u16;
-                out.push(HalfWord::Half(0b0100 | (zigzag >> 8) as u8));
-                out.push(HalfWord::Byte(zigzag as u8));
-            }
-            -32678..=32767 => {
-                let zigzag = value.zigzag_bit_masked(0b1111_1111_1111_1111) as u16;
-                out.push(HalfWord::Half(0b0110));
-                out.push(HalfWord::Byte((zigzag >> 8) as u8));
-                out.push(HalfWord::Byte(zigzag as u8));
-            }
-            _ => {
-                let zigzag = value.zigzag_bits();
-                out.push(HalfWord::Half(0b0111));
-                out.push(HalfWord::Full(zigzag));
-            }
-        }
-    }
-}
-
-impl EmitDeltaDeltaBits<i32> for CompressionQueue<i32, 2> {
+impl EmitDeltaDeltaBits for CompressionQueue<2> {
     fn emit_delta_delta_bits(&mut self, out: &mut HalfVec) -> usize {
         match self.len() {
             2 => {
-                let values = unsafe { self.pop_n::<2>().unwrap_unchecked() };
-                emit_popped_values32(&values, out);
+                let bitcounts = self.peak_bitcounts::<2>();
+                let values = self.pop_n::<2>();
+                emit_popped_values(&bitcounts, &values, out);
                 return 2;
             }
-            _ => {
-                let len = self.len();
-                emit_popped_values32_q(self, out);
-                return len;
+            1 => {
+                let bitcounts = self.peak_bitcounts::<1>();
+                let values = self.pop_n::<1>();
+                emit_popped_values(&bitcounts, &values, out);
+                return 1;
             }
-        }
-    }
-}
-
-fn emit_popped_values16<const N: usize>(values: &[i16; N], out: &mut HalfVec) {
-    for value in values {
-        match value {
-            0 => out.push(HalfWord::Half(0b0000)),
-            -1 => out.push(HalfWord::Half(0b0001)),
-            -16..=15 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111) as u8;
-                out.push(HalfWord::Byte(0b0010_0000 | zigzag));
-            }
-            -256..=255 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111_1111) as u16;
-                out.push(HalfWord::Half(0b0100 | (zigzag >> 8) as u8));
-                out.push(HalfWord::Byte(zigzag as u8));
-            }
-            -32678..=32767 => {
-                let zigzag = value.zigzag_bit_masked(0b1111_1111_1111_1111) as u16;
-                out.push(HalfWord::Half(0b0110));
-                out.push(HalfWord::Byte((zigzag >> 8) as u8));
-                out.push(HalfWord::Byte(zigzag as u8));
-            }
-            _ => {
-                let zigzag = value.zigzag_bits();
-                out.push(HalfWord::Half(0b0111));
-                out.push(HalfWord::Full(zigzag));
-            }
-        }
-    }
-}
-
-fn emit_popped_values16_q(q: &mut CompressionQueue<i16, 2>, out: &mut HalfVec) {
-    while !q.is_empty() {
-        let value = unsafe { q.pop().unwrap_unchecked() };
-        match value {
-            0 => out.push(HalfWord::Half(0b0000)),
-            -1 => out.push(HalfWord::Half(0b0001)),
-            -16..=15 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111) as u8;
-                out.push(HalfWord::Byte(0b0010_0000 | zigzag));
-            }
-            -256..=255 => {
-                let zigzag = value.zigzag_bit_masked(0b1_1111_1111) as u16;
-                out.push(HalfWord::Half(0b0100 | (zigzag >> 8) as u8));
-                out.push(HalfWord::Byte(zigzag as u8));
-            }
-            -32678..=32767 => {
-                let zigzag = value.zigzag_bit_masked(0b1111_1111_1111_1111) as u16;
-                out.push(HalfWord::Half(0b0110));
-                out.push(HalfWord::Byte((zigzag >> 8) as u8));
-                out.push(HalfWord::Byte(zigzag as u8));
-            }
-            _ => {
-                let zigzag = value.zigzag_bits();
-                out.push(HalfWord::Half(0b0111));
-                out.push(HalfWord::Full(zigzag));
-            }
-        }
-    }
-}
-
-impl EmitDeltaDeltaBits<i16> for CompressionQueue<i16, 2> {
-    fn emit_delta_delta_bits(&mut self, out: &mut HalfVec) -> usize {
-        match self.len() {
-            2 => {
-                let values = unsafe { self.pop_n::<2>().unwrap_unchecked() };
-                emit_popped_values16(&values, out);
-                return 2;
-            }
-            _ => {
-                let len = self.len();
-                emit_popped_values16_q(self, out);
-                return len;
-            }
+            _ => return 0,
         }
     }
 }

--- a/tsz-compress/src/v2/tests.rs
+++ b/tsz-compress/src/v2/tests.rs
@@ -21,7 +21,7 @@ mod tests_delta {
     ) -> (usize, usize, usize) {
         // Case 5: Encode and decode 10 samples between [-4, 3] in 3 bits
         // Create queue
-        let mut queue: CompressionQueue<i16, 10> = CompressionQueue::new();
+        let mut queue: CompressionQueue<10> = CompressionQueue::new();
         for value in values {
             queue.push(*value as i16);
         }
@@ -29,7 +29,11 @@ mod tests_delta {
         // Header
         bits.push(HalfWord::Half(0b1001));
         // Encode
-        let num_emitted_samples = queue.emit_delta_bits(&mut bits, flush);
+        let num_emitted_samples = if flush {
+            queue.flush_delta_bits(&mut bits)
+        } else {
+            queue.emit_delta_bits(&mut bits)
+        };
         if bits.len() % 2 == 1 {
             bits.push(HalfWord::Half(0b1001));
         }
@@ -50,7 +54,7 @@ mod tests_delta {
         flush: bool,
     ) -> (usize, usize, usize) {
         // Create queue
-        let mut queue: CompressionQueue<i16, 10> = CompressionQueue::new();
+        let mut queue: CompressionQueue<10> = CompressionQueue::new();
         for value in values {
             queue.push(*value);
         }

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -674,21 +674,21 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                 let segment = path.segments.first().unwrap();
                 let ident = segment.ident.clone();
                 match ident.to_string().as_str() {
-                    "i8" => quote! { 
+                    "i8" => quote! {
                         debug_assert!(self.#col_delta_buf_idents.is_some());
                         let outbuf = unsafe { self.#col_delta_buf_idents.as_mut().unwrap_unchecked() };
                         self.#col_delta_comp_queue_idents.push(delta);
                         if self.#col_delta_comp_queue_idents.is_full() {
-                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf, false);
+                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf);
                             self.#col_values_emitted_delta += emitted;
                         }
                     },
-                    "i16" => quote! { 
+                    "i16" => quote! {
                         debug_assert!(self.#col_delta_buf_idents.is_some());
                         let outbuf = unsafe { self.#col_delta_buf_idents.as_mut().unwrap_unchecked() };
                         self.#col_delta_comp_queue_idents.push(delta);
                         if self.#col_delta_comp_queue_idents.is_full() {
-                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf, false);
+                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf);
                             self.#col_values_emitted_delta += emitted;
                         }
                     },
@@ -697,16 +697,16 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                         let outbuf = unsafe { self.#col_delta_buf_idents.as_mut().unwrap_unchecked() };
                         self.#col_delta_comp_queue_idents.push(delta);
                         if self.#col_delta_comp_queue_idents.is_full() {
-                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf, false);
+                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf);
                             self.#col_values_emitted_delta += emitted;
                         }
                     },
-                    "i64" => quote! { 
+                    "i64" => quote! {
                         debug_assert!(self.#col_delta_buf_idents.is_some());
                         let outbuf = unsafe { self.#col_delta_buf_idents.as_mut().unwrap_unchecked() };
                         self.#col_delta_comp_queue_idents.push(delta);
                         if self.#col_delta_comp_queue_idents.is_full() {
-                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf, false);
+                            let emitted = self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf);
                             self.#col_values_emitted_delta += emitted;
                         }
                     },
@@ -753,8 +753,8 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                 /// A Compressor type implementing TszCompressV2.
                 #[derive(Debug)]
                 pub struct #compressor_ident {
-                    #( #col_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue<#delta_col_tys, 10>,)*
-                    #( #col_delta_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue<#delta_col_tys, 2>,)*
+                    #( #col_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue<10>,)*
+                    #( #col_delta_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue<2>,)*
                     #( #col_delta_buf_idents: Option<::tsz_compress::prelude::halfvec::HalfVec>,)*
                     #( #col_delta_delta_buf_idents: Option<::tsz_compress::prelude::halfvec::HalfVec>,)*
                     #( #col_values_emitted_delta: usize,)*
@@ -773,8 +773,8 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                     /// emitted during the delta and delta-delta compression processes.
                     fn new(prealloc_rows: usize) -> Self {
                         #compressor_ident {
-                            #( #col_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue::<#delta_col_tys, 10>::new(),)*
-                            #( #col_delta_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue::<#delta_col_tys, 2>::new(),)*
+                            #( #col_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue::<10>::new(),)*
+                            #( #col_delta_delta_comp_queue_idents: ::tsz_compress::prelude::CompressionQueue::<2>::new(),)*
                             #( #col_delta_buf_idents: #col_delta_buf,)*
                             #( #col_delta_delta_buf_idents: #col_delta_delta_buf,)*
                             #( #col_values_emitted_delta: 0,)*
@@ -917,7 +917,7 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                         #(
                             self.#col_delta_buf_idents.as_mut().map(|outbuf| {
                                 while self.#col_delta_comp_queue_idents.len() > 0 {
-                                    self.#col_delta_comp_queue_idents.emit_delta_bits(outbuf, true);
+                                    self.#col_delta_comp_queue_idents.flush_delta_bits(outbuf);
                                 }
                              });
                             self.#col_delta_delta_buf_idents.as_mut().map(|outbuf| {


### PR DESCRIPTION
This removes `T` generics of the CompressionQueue in favor of holding zigzag bits and bits of information counts. This allows zigzag encoding to be calculated once and range checks to be converted to a single comparison. This yields another 5% performance improvement on Cortex-M4.