### PR TITLE
Add field attributes in proc macros for delta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,9 +387,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -577,6 +577,7 @@ name = "tsz-macro"
 version = "1.1.0"
 dependencies = [
  "itertools 0.11.0",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/tsz-compress/tests/compress-v2.rs
+++ b/tsz-compress/tests/compress-v2.rs
@@ -1055,7 +1055,7 @@ mod test_field_attributes {
         let mut compressor = TestRowCompressorImpl::new(128);
 
         // Initialize the values vector
-        let mut values: Vec<i32> = Vec::with_capacity((i32::MAX as usize + 1) * 4 + 2);
+        let mut values: Vec<i32> = Vec::with_capacity((i8::MAX as usize + 1) * 4 + 2);
 
         // Write the first and second value
         compressor.compress(TestRow { a: 0 });

--- a/tsz-compress/tests/compress-v2.rs
+++ b/tsz-compress/tests/compress-v2.rs
@@ -12,7 +12,7 @@ mod tests {
     use rand::Rng;
 
     #[test]
-    fn test_macro_compress_sanity1_i8() {
+    fn test_macro_compress_sanity_i8_bit_width_values1() {
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -51,7 +51,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_sanity2_i8() {
+    fn test_macro_compress_sanity_i8_bit_width_values2() {
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -103,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_random_i8() {
+    fn test_macro_compress_i8_bit_width_values_random() {
         // Test with random values within i8 range
         mod row {
             use tsz_compress::prelude::*;
@@ -153,8 +153,8 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_all_i8_bit_width_deltas() {
-        // Test with deltas out of i8 range
+    fn test_macro_compress_i8_bit_width_values_all_deltas() {
+        // Test with all deltas possible by i8 bit-widths values
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_sanity1_i16() {
+    fn test_macro_compress_sanity_i16_bit_width_values1() {
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_sanity2_i16() {
+    fn test_macro_compress_sanity_i16_bit_width_values2() {
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_sanity3_i16() {
+    fn test_macro_compress_sanity_i16_bit_width_values3() {
         // Test with deltas out of i16 range
         mod row {
             use tsz_compress::prelude::*;
@@ -322,7 +322,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_random_i16() {
+    fn test_macro_compress_i16_bit_width_values_random() {
         // Test with random values within i16 range
         mod row {
             use tsz_compress::prelude::*;
@@ -372,8 +372,8 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_all_i16_bit_width_deltas() {
-        // Test with deltas out of i16 range
+    fn test_macro_compress_i16_bit_width_values_all_deltas() {
+        // Test with all deltas possible by i16 bit-widths values
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -427,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_sanity1_i32() {
+    fn test_macro_compress_sanity_i32_bit_width_values1() {
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_sanity2_i32() {
+    fn test_macro_compress_sanity_i32_bit_width_values2() {
         // Test with delta within i32 range
         mod row {
             use tsz_compress::prelude::*;
@@ -504,12 +504,713 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_compress_random_i32() {
+    fn test_macro_compress_i32_bit_width_values_random() {
         // Test with random values with delta within i32 range
         mod row {
             use tsz_compress::prelude::*;
             #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
             pub struct TestRow {
+                pub a: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..1000 {
+            // Initialize the compressor
+            let mut compressor = TestRowCompressorImpl::new(128);
+
+            // Number of samples in the input vector
+            let end_range = rng.gen_range(100..10000);
+
+            // Generate input vector randomly such that delta is in i32 range
+            let values: Vec<i32> = (0..end_range)
+                .map(|_| rng.gen_range((i32::MIN / 2)..(i32::MAX - 1) / 2))
+                .collect();
+
+            // Compression
+            for value in &values {
+                let row = TestRow { a: *value };
+                compressor.compress(row);
+            }
+
+            // Finalize the compression
+            let bytes = compressor.finish();
+
+            // Initialize the decompressor
+            let mut decompressor = TestRowDecompressorImpl::new();
+
+            // Decompress the bit buffer
+            decompressor.decompress(&bytes).unwrap();
+
+            // Assert that the decompressed data matches the original
+            assert_eq!(values, decompressor.col_a());
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_field_attributes {
+
+    use super::*;
+    use rand::Rng;
+
+    #[test]
+    fn test_macro_compress_sanity_i8_bit_width_values() {
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i8")]
+                pub a: i8,
+                #[tsz(delta = "i16")]
+                pub b: i8,
+                #[tsz(delta = "i32")]
+                pub c: i8,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+        const N: usize = 20;
+
+        /// Test 10 samples (size of queue)
+        let row = TestRow { a: 1, b: 1, c: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+        assert_eq!(decompressor.col_b(), vec![row.b; N]);
+        assert_eq!(decompressor.col_c(), vec![row.c; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_sanity_i16_bit_width_values() {
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i8")]
+                pub a: i16,
+                #[tsz(delta = "i16")]
+                pub b: i16,
+                #[tsz(delta = "i32")]
+                pub c: i16,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+        const N: usize = 20;
+
+        /// Test 10 samples (size of queue)
+        let row = TestRow { a: 1, b: 1, c: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+        assert_eq!(decompressor.col_b(), vec![row.b; N]);
+        assert_eq!(decompressor.col_c(), vec![row.c; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_sanity_i32_bit_width_values() {
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i8")]
+                pub a: i32,
+                #[tsz(delta = "i16")]
+                pub b: i32,
+                #[tsz(delta = "i32")]
+                pub c: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+        const N: usize = 20;
+
+        /// Test 10 samples (size of queue)
+        let row = TestRow { a: 1, b: 1, c: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+        assert_eq!(decompressor.col_b(), vec![row.b; N]);
+        assert_eq!(decompressor.col_c(), vec![row.c; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i8_value_i8_delta_all() {
+        // Test with all i8 deltas possible by i8 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i8")]
+                pub a: i8,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i8> = Vec::with_capacity((i8::MAX as usize + 1) * 8 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in i8::MIN / 2..=(i8::MAX - 1) / 2 {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i8::MIN / 2 });
+            values.push(i);
+            values.push(i8::MIN / 2);
+        }
+
+        for i in i8::MIN / 2..=(i8::MAX - 1) / 2 {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: (i8::MAX - 1) / 2,
+            });
+            values.push(i);
+            values.push((i8::MAX - 1) / 2);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i8_value_i16_delta_all() {
+        // Test with all i16 deltas possible by i8 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i16")]
+                pub a: i8,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i8> = Vec::with_capacity((i8::MAX as usize + 1) * 8 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in i8::MIN..=i8::MAX {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i8::MIN });
+            values.push(i);
+            values.push(i8::MIN);
+        }
+
+        for i in i8::MIN..=i8::MAX {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i8::MAX });
+            values.push(i);
+            values.push(i8::MAX);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i8_value_i32_delta_all() {
+        // Test with all i32 deltas possible by i8 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i32")]
+                pub a: i8,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i8> = Vec::with_capacity((i8::MAX as usize + 1) * 8 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in i8::MIN..=i8::MAX {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i8::MIN });
+            values.push(i);
+            values.push(i8::MIN);
+        }
+
+        for i in i8::MIN..=i8::MAX {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i8::MAX });
+            values.push(i);
+            values.push(i8::MAX);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i16_value_i8_delta_all() {
+        // Test with all i8 deltas possible by i16 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i8")]
+                pub a: i16,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i16> = Vec::with_capacity((i16::MAX as usize + 1) * 4 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in ((i8::MIN / 2) as i16)..=(((i8::MAX - 1) / 2) as i16) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: (i8::MIN / 2) as i16,
+            });
+            values.push(i);
+            values.push((i8::MIN / 2) as i16);
+        }
+
+        for i in ((i8::MIN / 2) as i16)..=(((i8::MAX - 1) / 2) as i16) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: ((i8::MAX - 1) / 2) as i16,
+            });
+            values.push(i);
+            values.push(((i8::MAX - 1) / 2) as i16);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i16_value_i16_delta_all() {
+        // Test with all i16 deltas possible by i16 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i16")]
+                pub a: i16,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i16> = Vec::with_capacity((i16::MAX as usize + 1) * 4 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in ((i16::MIN) / 2)..=((i16::MAX - 1) / 2) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: (i16::MIN) / 2 });
+            values.push(i);
+            values.push((i16::MIN) / 2);
+        }
+
+        for i in ((i16::MIN) / 2)..=((i16::MAX - 1) / 2) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: (i16::MAX - 1) / 2,
+            });
+            values.push(i);
+            values.push((i16::MAX - 1) / 2);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i16_value_i32_delta_all() {
+        // Test with all i32 deltas possible by i16 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i32")]
+                pub a: i16,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i16> = Vec::with_capacity((i16::MAX as usize + 1) * 8 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in i16::MIN..=i16::MAX {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i16::MIN });
+            values.push(i);
+            values.push(i16::MIN);
+        }
+
+        for i in i16::MIN..=i16::MAX {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow { a: i16::MAX });
+            values.push(i);
+            values.push(i16::MAX);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i32_value_i8_delta_all() {
+        // Test with all i8 deltas possible by i32 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i8")]
+                pub a: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i32> = Vec::with_capacity((i32::MAX as usize + 1) * 4 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in ((i8::MIN / 2) as i32)..=(((i8::MAX - 1) / 2) as i32) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: (i8::MIN / 2) as i32,
+            });
+            values.push(i);
+            values.push((i8::MIN / 2) as i32);
+        }
+
+        for i in ((i8::MIN / 2) as i32)..=(((i8::MAX - 1) / 2) as i32) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: ((i8::MAX - 1) / 2) as i32,
+            });
+            values.push(i);
+            values.push(((i8::MAX - 1) / 2) as i32);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i32_value_i16_delta_all() {
+        // Test with all i16 deltas possible by i32 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i16")]
+                pub a: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Initialize the values vector
+        let mut values: Vec<i32> = Vec::with_capacity((i16::MAX as usize + 1) * 4 + 2);
+
+        // Write the first and second value
+        compressor.compress(TestRow { a: 0 });
+        compressor.compress(TestRow { a: 0 });
+        values.push(0);
+        values.push(0);
+
+        for i in ((i16::MIN / 2) as i32)..=(((i16::MAX - 1) / 2) as i32) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: (i16::MIN / 2) as i32,
+            });
+            values.push(i);
+            values.push((i16::MIN / 2) as i32);
+        }
+
+        for i in ((i16::MIN / 2) as i32)..=(((i16::MAX - 1) / 2) as i32) {
+            compressor.compress(TestRow { a: i });
+            compressor.compress(TestRow {
+                a: ((i16::MAX - 1) / 2) as i32,
+            });
+            values.push(i);
+            values.push(((i16::MAX - 1) / 2) as i32);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i32_value_i32_delta_edge_cases() {
+        // Test with edge i32 deltas possible by i32 bit-widths values
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+        use row::*;
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        let values = vec![
+            1,
+            1,
+            i32::MIN / 2,
+            (i32::MAX - 1) / 2,
+            i32::MIN / 2,
+            (i32::MAX - 1) / 2,
+            i32::MIN / 2,
+            (i32::MAX - 1) / 2,
+            i32::MIN / 2,
+            (i32::MAX - 1) / 2,
+            1,
+        ];
+
+        for value in &values {
+            let row = TestRow { a: *value };
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        decompressor.decompress(&bytes).unwrap();
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(values, decompressor.col_a());
+    }
+
+    #[test]
+    fn test_macro_compress_i32_value_i32_delta_random() {
+        // Test with random values with delta within i32 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                #[tsz(delta = "i32")]
                 pub a: i32,
             }
 

--- a/tsz-macro/Cargo.toml
+++ b/tsz-macro/Cargo.toml
@@ -17,3 +17,4 @@ proc-macro = true
 quote = "1.0.33"
 syn = { version = "2.0.38", features = ["full", "extra-traits"] }
 itertools = "0.11.0"
+proc-macro2 = "1.0.70"

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -513,7 +513,7 @@ fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type, 
     for delta_attribute in delta_attributes {
         if let Some(delta_attr) = delta_attribute {
             for attr in delta_attr {
-                // There should only be one tsz attribute per field that would be delta. For delta-delta
+                // There should only be one tsz attribute per field: delta
                 if let Meta::List(meta_list) = attr.meta.clone() {
                     let tokens = meta_list.tokens.into_iter().peekable();
                     let mut identifier = String::new();

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -1,8 +1,9 @@
 use itertools::izip;
 use itertools::{multiunzip, Itertools};
 use proc_macro::TokenStream;
+use proc_macro2::TokenTree;
 use quote::{format_ident, quote};
-use syn::parse_macro_input;
+use syn::{parse_macro_input, Meta};
 
 #[proc_macro_derive(DeltaEncodable)]
 pub fn derive_delta_encodable(item: TokenStream) -> TokenStream {
@@ -484,7 +485,7 @@ pub fn derive_decompressible(item: TokenStream) -> TokenStream {
     .into()
 }
 
-fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type)> {
+fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type, Option<String>)> {
     let fields = match input.data {
         syn::Data::Struct(syn::DataStruct { fields, .. }) => fields,
         _ => panic!("Expected fields in derive(Builder) struct"),
@@ -493,10 +494,69 @@ fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type)>
         syn::Fields::Named(syn::FieldsNamed { named, .. }) => named,
         _ => panic!("Expected named fields in derive(Builder) struct"),
     };
-    named_fields
+
+    let col_attrs = named_fields
+        .clone()
         .into_iter()
-        .map(|f| (f.ident.unwrap(), f.ty))
-        .collect::<Vec<_>>()
+        .map(|f| f.attrs)
+        .collect::<Vec<_>>();
+
+    let delta_attributes = col_attrs
+        .iter()
+        .map(|attrs| {
+            let filtered_attrs: Vec<_> = attrs
+                .iter()
+                .filter(|attr| attr.path().is_ident("tsz"))
+                .collect();
+            if filtered_attrs.is_empty() {
+                None
+            } else {
+                Some(filtered_attrs)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut col_user_delta: Vec<Option<String>> = Vec::new();
+    for delta_attribute in delta_attributes {
+        if let Some(delta_attr) = delta_attribute {
+            for attr in delta_attr {
+                if let Meta::List(meta_list) = attr.meta.clone() {
+                    let tokens = meta_list.tokens.into_iter().peekable();
+
+                    let mut identifier = String::new();
+                    let mut punct = String::new();
+                    let mut literal = String::new();
+
+                    for token in tokens {
+                        if let TokenTree::Ident(ident) = &token {
+                            identifier = ident.to_string();
+                        }
+                        if let TokenTree::Punct(p) = &token {
+                            punct = p.to_string();
+                        }
+                        if let TokenTree::Literal(lit) = &token {
+                            literal = lit.to_string();
+                        }
+                    }
+                    if identifier == "delta" && punct == "=" {
+                        col_user_delta.push(Some(literal));
+                    }
+                }
+            }
+        } else {
+            col_user_delta.push(None);
+        }
+    }
+
+    let named_fields_with_attrs = named_fields
+        .into_iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let attr = &col_user_delta[i];
+            (f.ident.unwrap(), f.ty, attr.clone())
+        })
+        .collect::<Vec<_>>();
+    named_fields_with_attrs
 }
 
 ///
@@ -504,7 +564,7 @@ fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type)>
 /// a struct and generate a StructCompressor with statically sized columnar
 /// compression for the fields.
 ///
-#[proc_macro_derive(CompressV2)]
+#[proc_macro_derive(CompressV2, attributes(tsz))]
 pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input!(tokens as syn::DeriveInput);
     let ident = input.ident.clone();
@@ -514,7 +574,7 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
 
     // We will compress each of the fields as columns
     let columns = get_fields_of_struct(input);
-    let (col_idents, col_tys): (Vec<_>, Vec<_>) = multiunzip(columns);
+    let (col_idents, col_tys, col_attrs): (Vec<_>, Vec<_>, Vec<_>) = multiunzip(columns);
     let col_delta_comp_queue_idents = col_idents
         .iter()
         .map(|ident| format_ident!("{}_delta_compressor_queue", ident))
@@ -532,25 +592,34 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
         .map(|ident| format_ident!("{}_delta_delta_output_buffer", ident))
         .collect_vec();
     let num_columns = col_idents.len();
-    let delta_col_tys = col_tys
+
+    let delta_col_tys = col_attrs
         .iter()
-        .map(|ty| match ty {
-            syn::Type::Path(syn::TypePath { path, .. }) => {
-                let segment = path.segments.first().unwrap();
-                let ident = segment.ident.clone();
-                match ident.to_string().as_str() {
-                    "i8" => quote! { i16 },
-                    "i16" => quote! { i32 },
-                    "i32" => quote! { i32 }, // todo, make choice based on macro attributes for field
-                    // "i32" => quote! { i64 }, // performance too degraded
-                    "i64" => quote! { i32 }, // todo, make choice based on macro attributes for field
-                    // "i64" => quote! { i128 }, // performance too degraded
-                    _ => panic!("Unsupported type"),
+        .zip(&col_tys)
+        .map(|(attr, ty)| match attr.as_ref() {
+            Some(s) if s == "\"i8\"" => quote! { i8 },
+            Some(s) if s == "\"i16\"" => quote! { i16 },
+            Some(s) if s == "\"i32\"" => quote! { i32 },
+            Some(s) if s == "\"i64\"" => quote! { i64 },
+            None => match ty {
+                // Default Deltas
+                syn::Type::Path(syn::TypePath { path, .. }) => {
+                    let segment = path.segments.first().unwrap();
+                    let ident = segment.ident.clone();
+                    match ident.to_string().as_str() {
+                        "i8" => quote! { i16 },
+                        "i16" => quote! { i32 },
+                        "i32" => quote! { i64 },
+                        "i64" => quote! { i64 },
+                        _ => panic!("Unsupported type"),
+                    }
                 }
-            }
+                _ => panic!("Unsupported type"),
+            },
             _ => panic!("Unsupported type"),
         })
         .collect::<Vec<_>>();
+
     let double_col_tys = col_tys
         .iter()
         .map(|ty| match ty {
@@ -960,7 +1029,7 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
     let decompressor_ident = format_ident!("{}DecompressorImpl", ident);
 
     let columns = get_fields_of_struct(input);
-    let (col_idents, col_tys): (Vec<_>, Vec<_>) = multiunzip(columns);
+    let (col_idents, col_tys, _col_attrs): (Vec<_>, Vec<_>, Vec<_>) = multiunzip(columns);
 
     let col_vec_idents = col_idents
         .iter()

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -595,7 +595,7 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
             Some(s) if s == "\"i8\"" => quote! { i8 },
             Some(s) if s == "\"i16\"" => quote! { i16 },
             Some(s) if s == "\"i32\"" => quote! { i32 },
-            Some(s) if s == "\"i64\"" => quote! { i64 },
+            // Some(s) if s == "\"i64\"" => quote! { i64 },
             None => match ty {
                 // Default Deltas
                 syn::Type::Path(syn::TypePath { path, .. }) => {
@@ -604,8 +604,8 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                     match ident.to_string().as_str() {
                         "i8" => quote! { i16 },
                         "i16" => quote! { i32 },
-                        "i32" => quote! { i64 },
-                        "i64" => quote! { i64 },
+                        "i32" => quote! { i32 },
+                        "i64" => quote! { i32 },
                         _ => panic!("Unsupported type"),
                     }
                 }


### PR DESCRIPTION
We have extended the functionality of procedural macros to accept field attributes for columns. This enhancement allows users to specify their own delta for each field in a struct.

Here's an example of how you can use this new feature:
```rust
pub struct TestRow {
    #[tsz(delta = "i16")]
    pub a: i32,
}
```
In the TestRow struct, the a field has a tsz attribute with a `delta` parameter set to `i16`. This means that the a field will use a user-specified delta of i16 for its time series compression.

This feature provides users with greater control over the time series compression of individual fields, allowing them to optimize the compression based on their specific use case and data characteristics.