### PR TITLE
Replace hardcoded header values with named constants

### DIFF
--- a/tsz-compress/src/v2/constants.rs
+++ b/tsz-compress/src/v2/constants.rs
@@ -1,0 +1,13 @@
+pub struct Headers;
+
+impl Headers {
+    pub const START_OF_COLUMN: u8 = 0b1001;
+
+    // DELTA ENCODING
+    pub const THREE_BITS_TEN_SAMPLES: u8 = 0b1111;
+    pub const SIX_BITS_FIVE_SAMPLES: u8 = 0b1110;
+    pub const EIGHT_BITS_FOUR_SAMPLES: u8 = 0b1100;
+    pub const TEN_BITS_THREE_SAMPLES: u8 = 0b1010;
+    pub const SIXTEEN_BITS_TWO_SAMPLES: u8 = 0b1000;
+    pub const THIRTY_TWO_BITS_ONE_SAMPLE: u8 = 0b1011;
+}

--- a/tsz-compress/src/v2/consts.rs
+++ b/tsz-compress/src/v2/consts.rs
@@ -1,6 +1,4 @@
-pub struct Headers;
-
-impl Headers {
+pub mod headers {
     pub const START_OF_COLUMN: u8 = 0b1001;
 
     // DELTA ENCODING

--- a/tsz-compress/src/v2/decode.rs
+++ b/tsz-compress/src/v2/decode.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
+use crate::v2::constants::Headers;
 use alloc::vec::Vec;
-
 ///
 /// An iterator over nibbles in the slice of bytes.
 ///
@@ -120,11 +120,11 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
     // Every thing is delta or delta-delta encoded from here on out
     while let Some(tag) = iter.next() {
         match tag {
-            0b1001 => {
+            Headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            0b1111 => {
+            Headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -145,7 +145,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            0b1110 => {
+            Headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -166,7 +166,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            0b1100 => {
+            Headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -187,7 +187,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            0b1010 => {
+            Headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -208,7 +208,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            0b1000 => {
+            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -229,7 +229,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            0b1011 => {
+            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -296,11 +296,11 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
 
     while let Some(tag) = iter.next() {
         match tag {
-            0b1001 => {
+            Headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            0b1111 => {
+            Headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -321,7 +321,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            0b1110 => {
+            Headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -342,7 +342,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            0b1100 => {
+            Headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -363,7 +363,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            0b1010 => {
+            Headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -384,7 +384,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            0b1000 => {
+            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -405,7 +405,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            0b1011 => {
+            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -484,11 +484,11 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
 
     while let Some(tag) = iter.next() {
         match tag {
-            0b1001 => {
+            Headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            0b1111 => {
+            Headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -509,7 +509,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            0b1110 => {
+            Headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -530,7 +530,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            0b1100 => {
+            Headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -552,7 +552,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                 }
             }
 
-            0b1010 => {
+            Headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -573,7 +573,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            0b1000 => {
+            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -594,7 +594,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            0b1011 => {
+            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -697,11 +697,11 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
 
     while let Some(tag) = iter.next() {
         match tag {
-            0b1001 => {
+            Headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            0b1111 => {
+            Headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -722,7 +722,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            0b1110 => {
+            Headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -743,7 +743,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            0b1100 => {
+            Headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -765,7 +765,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                 }
             }
 
-            0b1010 => {
+            Headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -786,7 +786,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            0b1000 => {
+            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -807,7 +807,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            0b1011 => {
+            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {

--- a/tsz-compress/src/v2/decode.rs
+++ b/tsz-compress/src/v2/decode.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::v2::constants::Headers;
+use crate::v2::consts::headers;
 use alloc::vec::Vec;
 ///
 /// An iterator over nibbles in the slice of bytes.
@@ -120,11 +120,11 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
     // Every thing is delta or delta-delta encoded from here on out
     while let Some(tag) = iter.next() {
         match tag {
-            Headers::START_OF_COLUMN => {
+            headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            Headers::THREE_BITS_TEN_SAMPLES => {
+            headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -145,7 +145,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            Headers::SIX_BITS_FIVE_SAMPLES => {
+            headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -166,7 +166,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            Headers::EIGHT_BITS_FOUR_SAMPLES => {
+            headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -187,7 +187,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            Headers::TEN_BITS_THREE_SAMPLES => {
+            headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -208,7 +208,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
+            headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -229,7 +229,7 @@ pub fn decode_i8<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i8>) -> Result<
                     output.push(value);
                 }
             }
-            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
+            headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -296,11 +296,11 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
 
     while let Some(tag) = iter.next() {
         match tag {
-            Headers::START_OF_COLUMN => {
+            headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            Headers::THREE_BITS_TEN_SAMPLES => {
+            headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -321,7 +321,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::SIX_BITS_FIVE_SAMPLES => {
+            headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -342,7 +342,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::EIGHT_BITS_FOUR_SAMPLES => {
+            headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -363,7 +363,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::TEN_BITS_THREE_SAMPLES => {
+            headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -384,7 +384,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
+            headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -405,7 +405,7 @@ pub fn decode_i16<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i16>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
+            headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -484,11 +484,11 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
 
     while let Some(tag) = iter.next() {
         match tag {
-            Headers::START_OF_COLUMN => {
+            headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            Headers::THREE_BITS_TEN_SAMPLES => {
+            headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -509,7 +509,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::SIX_BITS_FIVE_SAMPLES => {
+            headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -530,7 +530,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::EIGHT_BITS_FOUR_SAMPLES => {
+            headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -552,7 +552,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                 }
             }
 
-            Headers::TEN_BITS_THREE_SAMPLES => {
+            headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -573,7 +573,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
+            headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -594,7 +594,7 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
+            headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -697,11 +697,11 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
 
     while let Some(tag) = iter.next() {
         match tag {
-            Headers::START_OF_COLUMN => {
+            headers::START_OF_COLUMN => {
                 // Start of column of next column
                 break;
             }
-            Headers::THREE_BITS_TEN_SAMPLES => {
+            headers::THREE_BITS_TEN_SAMPLES => {
                 // 2 bit pad, 10 samples of 3 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -722,7 +722,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::SIX_BITS_FIVE_SAMPLES => {
+            headers::SIX_BITS_FIVE_SAMPLES => {
                 // 5 samples of 6 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -743,7 +743,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::EIGHT_BITS_FOUR_SAMPLES => {
+            headers::EIGHT_BITS_FOUR_SAMPLES => {
                 // 4 samples of 8 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -765,7 +765,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                 }
             }
 
-            Headers::TEN_BITS_THREE_SAMPLES => {
+            headers::TEN_BITS_THREE_SAMPLES => {
                 // 2 bit pad, 3 samples of 10 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -786,7 +786,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::SIXTEEN_BITS_TWO_SAMPLES => {
+            headers::SIXTEEN_BITS_TWO_SAMPLES => {
                 // 2 samples of 16 bit
                 let mut word: u32 = 0;
                 for _ in 0..7 {
@@ -807,7 +807,7 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                     output.push(value);
                 }
             }
-            Headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
+            headers::THIRTY_TWO_BITS_ONE_SAMPLE => {
                 // 1 sample of 32 bits
                 let mut word: u32 = 0;
                 for _ in 0..7 {

--- a/tsz-compress/src/v2/encode.rs
+++ b/tsz-compress/src/v2/encode.rs
@@ -1,8 +1,8 @@
 use core::fmt::Binary;
-
 use num_traits::PrimInt;
 
 use crate::prelude::*;
+use crate::v2::constants::Headers;
 
 use super::halfvec::{HalfVec, HalfWord};
 
@@ -62,7 +62,7 @@ impl Bits for i64 {
 fn push_three_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 10;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(0b1111));
+    buf.push(HalfWord::Half(Headers::THREE_BITS_TEN_SAMPLES));
     let mut word: usize = 0;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -77,7 +77,7 @@ fn push_three_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_six_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 5;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(0b1110));
+    buf.push(HalfWord::Half(Headers::SIX_BITS_FIVE_SAMPLES));
     let mut word: usize = 0;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -92,7 +92,7 @@ fn push_six_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_eight_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 4;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(0b1100));
+    buf.push(HalfWord::Half(Headers::EIGHT_BITS_FOUR_SAMPLES));
     let mut word: usize = 0;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -107,7 +107,7 @@ fn push_eight_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_ten_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 3;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(0b1010));
+    buf.push(HalfWord::Half(Headers::TEN_BITS_THREE_SAMPLES));
     let mut word: usize = 0b00 << 10;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -122,7 +122,7 @@ fn push_ten_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_sixteen_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 2;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(0b1000));
+    buf.push(HalfWord::Half(Headers::SIXTEEN_BITS_TWO_SAMPLES));
     let mut word: usize = 0b00 << 10;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -135,7 +135,7 @@ fn push_sixteen_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 
 #[inline(always)]
 unsafe fn push_thirty_two_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
-    buf.push(HalfWord::Half(0b1011));
+    buf.push(HalfWord::Half(Headers::THIRTY_TWO_BITS_ONE_SAMPLE));
     let value = q.pop().unwrap_unchecked() as u32;
     buf.push(HalfWord::Full(value));
 }

--- a/tsz-compress/src/v2/encode.rs
+++ b/tsz-compress/src/v2/encode.rs
@@ -2,7 +2,7 @@ use core::fmt::Binary;
 use num_traits::PrimInt;
 
 use crate::prelude::*;
-use crate::v2::constants::Headers;
+use crate::v2::consts::headers;
 
 use super::halfvec::{HalfVec, HalfWord};
 
@@ -62,7 +62,7 @@ impl Bits for i64 {
 fn push_three_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 10;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(Headers::THREE_BITS_TEN_SAMPLES));
+    buf.push(HalfWord::Half(headers::THREE_BITS_TEN_SAMPLES));
     let mut word: usize = 0;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -77,7 +77,7 @@ fn push_three_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_six_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 5;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(Headers::SIX_BITS_FIVE_SAMPLES));
+    buf.push(HalfWord::Half(headers::SIX_BITS_FIVE_SAMPLES));
     let mut word: usize = 0;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -92,7 +92,7 @@ fn push_six_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_eight_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 4;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(Headers::EIGHT_BITS_FOUR_SAMPLES));
+    buf.push(HalfWord::Half(headers::EIGHT_BITS_FOUR_SAMPLES));
     let mut word: usize = 0;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -107,7 +107,7 @@ fn push_eight_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_ten_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 3;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(Headers::TEN_BITS_THREE_SAMPLES));
+    buf.push(HalfWord::Half(headers::TEN_BITS_THREE_SAMPLES));
     let mut word: usize = 0b00 << 10;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -122,7 +122,7 @@ fn push_ten_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 fn push_sixteen_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
     const N: usize = 2;
     const N1: usize = N - 1;
-    buf.push(HalfWord::Half(Headers::SIXTEEN_BITS_TWO_SAMPLES));
+    buf.push(HalfWord::Half(headers::SIXTEEN_BITS_TWO_SAMPLES));
     let mut word: usize = 0b00 << 10;
     let values = q.pop_n::<N>();
     for i in 0..N1 {
@@ -135,7 +135,7 @@ fn push_sixteen_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 
 #[inline(always)]
 unsafe fn push_thirty_two_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
-    buf.push(HalfWord::Half(Headers::THIRTY_TWO_BITS_ONE_SAMPLE));
+    buf.push(HalfWord::Half(headers::THIRTY_TWO_BITS_ONE_SAMPLE));
     let value = q.pop().unwrap_unchecked() as u32;
     buf.push(HalfWord::Full(value));
 }

--- a/tsz-compress/src/v2/halfvec.rs
+++ b/tsz-compress/src/v2/halfvec.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use crate::prelude::*;
-use crate::v2::constants::Headers;
+use crate::v2::consts::headers;
 use alloc::vec::Vec;
 pub use queue::*;
 
@@ -178,8 +178,8 @@ impl HalfVec {
             }
 
             if !upper {
-                // We are on the lower nibble, so fill the upper nibble with Headers::START_OF_COLUMN
-                byte |= Headers::START_OF_COLUMN;
+                // We are on the lower nibble, so fill the upper nibble with headers::START_OF_COLUMN
+                byte |= headers::START_OF_COLUMN;
                 known_append(&mut bytes, byte);
             }
 
@@ -295,7 +295,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(Headers::THREE_BITS_TEN_SAMPLES));
+        expected_halfvec.push(HalfWord::Half(headers::THREE_BITS_TEN_SAMPLES));
 
         // Values: [-3, 2, 0, 1, 2, -3, -1, -2, -4, -3]
         // Zigzag values: [5, 4, 0, 2, 4, 5, 1, 3, 7, 5]
@@ -318,7 +318,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(Headers::SIX_BITS_FIVE_SAMPLES));
+        expected_halfvec.push(HalfWord::Half(headers::SIX_BITS_FIVE_SAMPLES));
 
         // Values: [-32, 31, 16, 1, 2]
         // Zigzag values: [63, 62, 32, 2, 4]
@@ -341,7 +341,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(Headers::EIGHT_BITS_FOUR_SAMPLES));
+        expected_halfvec.push(HalfWord::Half(headers::EIGHT_BITS_FOUR_SAMPLES));
 
         // Values: [-128, 127, 64, 1]
         // Zigzag values: [255, 254, 128, 2]
@@ -364,7 +364,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(Headers::TEN_BITS_THREE_SAMPLES));
+        expected_halfvec.push(HalfWord::Half(headers::TEN_BITS_THREE_SAMPLES));
 
         // Values: [-512, 511, 256]
         // Zigzag values: [1023, 1022, 512]
@@ -387,7 +387,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(Headers::SIXTEEN_BITS_TWO_SAMPLES));
+        expected_halfvec.push(HalfWord::Half(headers::SIXTEEN_BITS_TWO_SAMPLES));
 
         // Values: [-32768, 32767]
         // Zigzag values: [65535, 65534]
@@ -410,7 +410,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(Headers::THIRTY_TWO_BITS_ONE_SAMPLE));
+        expected_halfvec.push(HalfWord::Half(headers::THIRTY_TWO_BITS_ONE_SAMPLE));
 
         // Values: vec![i32::MIN / 4]
         // Zigzag values: [-1 * i32::MIN / 2]

--- a/tsz-compress/src/v2/halfvec.rs
+++ b/tsz-compress/src/v2/halfvec.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::prelude::*;
+use crate::v2::constants::Headers;
 use alloc::vec::Vec;
 pub use queue::*;
 
@@ -177,8 +178,8 @@ impl HalfVec {
             }
 
             if !upper {
-                // We are on the lower nibble, so fill the upper nibble with 0b1001
-                byte |= 0b1001;
+                // We are on the lower nibble, so fill the upper nibble with Headers::START_OF_COLUMN
+                byte |= Headers::START_OF_COLUMN;
                 known_append(&mut bytes, byte);
             }
 
@@ -235,7 +236,7 @@ mod tests {
     }
 }
 
-// Delta-Delta Tests
+// Delta Tests
 #[cfg(test)]
 mod tests_emit_delta {
 
@@ -294,7 +295,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(0b1111));
+        expected_halfvec.push(HalfWord::Half(Headers::THREE_BITS_TEN_SAMPLES));
 
         // Values: [-3, 2, 0, 1, 2, -3, -1, -2, -4, -3]
         // Zigzag values: [5, 4, 0, 2, 4, 5, 1, 3, 7, 5]
@@ -317,7 +318,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(0b1110));
+        expected_halfvec.push(HalfWord::Half(Headers::SIX_BITS_FIVE_SAMPLES));
 
         // Values: [-32, 31, 16, 1, 2]
         // Zigzag values: [63, 62, 32, 2, 4]
@@ -340,7 +341,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(0b1100));
+        expected_halfvec.push(HalfWord::Half(Headers::EIGHT_BITS_FOUR_SAMPLES));
 
         // Values: [-128, 127, 64, 1]
         // Zigzag values: [255, 254, 128, 2]
@@ -363,7 +364,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(0b1010));
+        expected_halfvec.push(HalfWord::Half(Headers::TEN_BITS_THREE_SAMPLES));
 
         // Values: [-512, 511, 256]
         // Zigzag values: [1023, 1022, 512]
@@ -386,7 +387,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(0b1000));
+        expected_halfvec.push(HalfWord::Half(Headers::SIXTEEN_BITS_TWO_SAMPLES));
 
         // Values: [-32768, 32767]
         // Zigzag values: [65535, 65534]
@@ -409,7 +410,7 @@ mod tests_emit_delta {
         let mut expected_halfvec = HalfVec::new(8);
 
         // Expecting 10 samples of 3 bits
-        expected_halfvec.push(HalfWord::Half(0b1011));
+        expected_halfvec.push(HalfWord::Half(Headers::THIRTY_TWO_BITS_ONE_SAMPLE));
 
         // Values: vec![i32::MIN / 4]
         // Zigzag values: [-1 * i32::MIN / 2]

--- a/tsz-compress/src/v2/mod.rs
+++ b/tsz-compress/src/v2/mod.rs
@@ -1,3 +1,4 @@
+pub mod constants;
 pub mod decode;
 pub mod encode;
 pub mod halfvec;

--- a/tsz-compress/src/v2/mod.rs
+++ b/tsz-compress/src/v2/mod.rs
@@ -1,4 +1,4 @@
-pub mod constants;
+pub mod consts;
 pub mod decode;
 pub mod encode;
 pub mod halfvec;

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -796,11 +796,11 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                             /// Write out the full value in the exact bit-width of the column.
                             #(
                                 if let Some(outbuf) = self.#col_delta_buf_idents.as_mut() {
-                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN));
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::START_OF_COLUMN));
                                     #write_first(outbuf, row.#col_idents);
                                 }
                                 if let Some(outbuf) = self.#col_delta_delta_buf_idents.as_mut() {
-                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN));
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::START_OF_COLUMN));
                                     #write_first(outbuf, row.#col_idents);
                                 }
                                 self.#prev_double_col_idents = row.#col_idents as #double_col_tys;
@@ -1046,8 +1046,8 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
                         // Iterate over the bits
                         let mut iter = HalfIter::new(bytes);
 
-                        // Expect a Headers::START_OF_COLUMN tag indicating the start of a new column
-                        if iter.next() != Some(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN) {
+                        // Expect a headers::START_OF_COLUMN tag indicating the start of a new column
+                        if iter.next() != Some(::tsz_compress::prelude::consts::headers::START_OF_COLUMN) {
                             #( self.#col_vec_idents.clear(); )*
                             return Err(CodingError::InvalidInitialColumnTag);
                         }
@@ -1057,7 +1057,7 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
 
                         // Pad nibbles to byte-alignment
                         match iter.next() {
-                            Some(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN) => (),
+                            Some(::tsz_compress::prelude::consts::headers::START_OF_COLUMN) => (),
                             Some(_) => return Err(CodingError::InvalidColumnTag),
                             None => (),
                         }

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -796,11 +796,11 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                             /// Write out the full value in the exact bit-width of the column.
                             #(
                                 if let Some(outbuf) = self.#col_delta_buf_idents.as_mut() {
-                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(0b1001));
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN));
                                     #write_first(outbuf, row.#col_idents);
                                 }
                                 if let Some(outbuf) = self.#col_delta_delta_buf_idents.as_mut() {
-                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(0b1001));
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN));
                                     #write_first(outbuf, row.#col_idents);
                                 }
                                 self.#prev_double_col_idents = row.#col_idents as #double_col_tys;
@@ -1046,8 +1046,8 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
                         // Iterate over the bits
                         let mut iter = HalfIter::new(bytes);
 
-                        // Expect a 1001 tag indicating the start of a new column
-                        if iter.next() != Some(0b1001) {
+                        // Expect a Headers::START_OF_COLUMN tag indicating the start of a new column
+                        if iter.next() != Some(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN) {
                             #( self.#col_vec_idents.clear(); )*
                             return Err(CodingError::InvalidInitialColumnTag);
                         }
@@ -1057,7 +1057,7 @@ pub fn derive_decompressv2(tokens: TokenStream) -> TokenStream {
 
                         // Pad nibbles to byte-alignment
                         match iter.next() {
-                            Some(0b1001) => (),
+                            Some(::tsz_compress::prelude::constants::Headers::START_OF_COLUMN) => (),
                             Some(_) => return Err(CodingError::InvalidColumnTag),
                             None => (),
                         }


### PR DESCRIPTION
### Summary

This PR replaces the hardcoded header values in the codebase with named constants for improved readability and maintainability. 


### Changes
- Defined `Headers` struct in `constants.rs` that contains named constants for each header value.
- Replaced all instances of hardcoded header values in the codebase with the corresponding constants from the `Headers` struct.


### Impact
These changes do not alter the functionality of the code. They only make the code easier to read and maintain.