### PR TITLE
Implement 64 bits 1 sample delta compression case

### DIFF
--- a/tsz-compress/src/v2/consts.rs
+++ b/tsz-compress/src/v2/consts.rs
@@ -8,4 +8,5 @@ pub mod headers {
     pub const TEN_BITS_THREE_SAMPLES: u8 = 0b1010;
     pub const SIXTEEN_BITS_TWO_SAMPLES: u8 = 0b1000;
     pub const THIRTY_TWO_BITS_ONE_SAMPLE: u8 = 0b1011;
+    pub const SIXTY_FOUR_BITS_ONE_SAMPLE: u8 = 0b1101;
 }

--- a/tsz-compress/src/v2/decode.rs
+++ b/tsz-compress/src/v2/decode.rs
@@ -615,6 +615,27 @@ pub fn decode_i32<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i32>) -> Resul
                     output.push(value);
                 }
             }
+            headers::SIXTY_FOUR_BITS_ONE_SAMPLE => {
+                // 1 sample of 64 bits
+                let mut word: u64 = 0;
+                for _ in 0..15 {
+                    let half = iter.next().ok_or(CodingError::NotEnoughBits)?;
+                    word |= half as u64;
+                    word <<= 4;
+                }
+                let half = iter.next().ok_or(CodingError::NotEnoughBits)?;
+                word |= half as u64;
+
+                let padding = 0;
+                let bit_width = 64;
+                let shift = 64 - padding - bit_width;
+                for i in 0..1 {
+                    let delta = (word >> (shift - bit_width * i)) as i64;
+                    let delta = (delta >> 1) ^ -(delta & 1);
+                    value = (value as i64 + delta) as i32;
+                    output.push(value);
+                }
+            }
             _ => {
                 // Delta-Delta encoding, or not implemented
                 todo!("Implement i32 delta-delta");
@@ -821,6 +842,27 @@ pub fn decode_i64<'it>(iter: &mut HalfIter<'it>, output: &mut Vec<i64>) -> Resul
                 let padding = 0;
                 let bit_width = 32;
                 let shift = 32 - padding - bit_width;
+                for i in 0..1 {
+                    let delta = (word >> (shift - bit_width * i)) as i128;
+                    let delta = (delta >> 1) ^ -(delta & 1);
+                    value = (value as i128 + delta) as i64;
+                    output.push(value);
+                }
+            }
+            headers::SIXTY_FOUR_BITS_ONE_SAMPLE => {
+                // 1 sample of 64 bits
+                let mut word: u64 = 0;
+                for _ in 0..15 {
+                    let half = iter.next().ok_or(CodingError::NotEnoughBits)?;
+                    word |= half as u64;
+                    word <<= 4;
+                }
+                let half = iter.next().ok_or(CodingError::NotEnoughBits)?;
+                word |= half as u64;
+
+                let padding = 0;
+                let bit_width = 64;
+                let shift = 64 - padding - bit_width;
                 for i in 0..1 {
                     let delta = (word >> (shift - bit_width * i)) as i128;
                     let delta = (delta >> 1) ^ -(delta & 1);

--- a/tsz-compress/src/v2/encode.rs
+++ b/tsz-compress/src/v2/encode.rs
@@ -134,17 +134,14 @@ fn push_sixteen_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
 }
 
 #[inline(always)]
-unsafe fn push_thirty_two_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
-    buf.push(HalfWord::Half(headers::THIRTY_TWO_BITS_ONE_SAMPLE));
-    let value = q.pop().unwrap_unchecked() as u32;
-    buf.push(HalfWord::Full(value));
-}
-
-#[inline(always)]
-unsafe fn push_sixty_four_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
-    buf.push(HalfWord::Half(headers::SIXTY_FOUR_BITS_ONE_SAMPLE));
-    let value = q.pop().unwrap_unchecked() as u64;
-    buf.push(HalfWord::Full((value >> 32) as u32));
+unsafe fn push_32_or_64_bits(q: &mut CompressionQueue<10>, buf: &mut HalfVec) {
+    let value = q.pop().unwrap_unchecked();
+    if value <= u32::MAX as usize {
+        buf.push(HalfWord::Half(headers::THIRTY_TWO_BITS_ONE_SAMPLE));
+    } else {
+        buf.push(HalfWord::Half(headers::SIXTY_FOUR_BITS_ONE_SAMPLE));
+        buf.push(HalfWord::Full((value >> 32) as u32));
+    }
     buf.push(HalfWord::Full(value as u32));
 }
 
@@ -158,14 +155,11 @@ pub trait EmitDeltaBits {
 impl EmitDeltaBits for CompressionQueue<10> {
     #[inline(always)]
     fn emit_delta_bits(&mut self, out: &mut HalfVec) -> usize {
-        let mut fits = [true; 6];
+        let mut fits = [true; 5];
 
         // Check if the values will fit in the cases
         let values = self.peak_bitcounts::<10>();
         for (index, bits_required) in values.into_iter().enumerate() {
-            if (index < 2) & (bits_required > 32) {
-                fits[5] = false;
-            }
             if (index < 2) & (bits_required > 16) {
                 fits[4] = false;
             }
@@ -199,14 +193,9 @@ impl EmitDeltaBits for CompressionQueue<10> {
         } else if fits[4] {
             push_sixteen_bits(self, out);
             return 2;
-        } else if fits[5] {
-            unsafe {
-                push_thirty_two_bits(self, out);
-            }
-            return 1;
         } else {
             unsafe {
-                push_sixty_four_bits(self, out);
+                push_32_or_64_bits(self, out);
             }
             return 1;
         }
@@ -214,7 +203,7 @@ impl EmitDeltaBits for CompressionQueue<10> {
 
     #[inline(always)]
     fn flush_delta_bits(&mut self, out: &mut HalfVec) -> usize {
-        let mut fits = [true; 6];
+        let mut fits = [true; 5];
 
         // Can not emit with any case of delta compression if queue is empty
         if self.is_empty() {
@@ -249,9 +238,6 @@ impl EmitDeltaBits for CompressionQueue<10> {
         // Check if the values will fit in the cases
         let values = self.peak_bitcounts::<10>();
         for (index, bits_required) in values.into_iter().enumerate() {
-            if (index < 2) & (bits_required > 32) {
-                fits[5] = false;
-            }
             if (index < 2) & (bits_required > 16) {
                 fits[4] = false;
             }
@@ -285,14 +271,9 @@ impl EmitDeltaBits for CompressionQueue<10> {
         } else if fits[4] {
             push_sixteen_bits(self, out);
             return 2;
-        } else if fits[5] {
-            unsafe {
-                push_thirty_two_bits(self, out);
-            }
-            return 1;
         } else {
             unsafe {
-                push_sixty_four_bits(self, out);
+                push_32_or_64_bits(self, out);
             }
             return 1;
         }

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -542,15 +542,14 @@ fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type, 
         }
     }
 
-    let named_fields_with_attrs = named_fields
+    named_fields
         .into_iter()
         .enumerate()
         .map(|(i, f)| {
             let attr = &delta_user_col_tys[i];
             (f.ident.unwrap(), f.ty, attr.clone())
         })
-        .collect::<Vec<_>>();
-    named_fields_with_attrs
+        .collect::<Vec<_>>() // (ident, ty, delta_bit_width)
 }
 
 ///
@@ -595,7 +594,7 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
             Some(s) if s == "\"i8\"" => quote! { i8 },
             Some(s) if s == "\"i16\"" => quote! { i16 },
             Some(s) if s == "\"i32\"" => quote! { i32 },
-            // Some(s) if s == "\"i64\"" => quote! { i64 },
+            Some(s) if s == "\"i64\"" => quote! { i64 },
             None => match ty {
                 // Default Deltas
                 syn::Type::Path(syn::TypePath { path, .. }) => {
@@ -604,8 +603,8 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                     match ident.to_string().as_str() {
                         "i8" => quote! { i16 },
                         "i16" => quote! { i32 },
-                        "i32" => quote! { i32 },
-                        "i64" => quote! { i32 },
+                        "i32" => quote! { i64 },
+                        "i64" => quote! { i64 },
                         _ => panic!("Unsupported type"),
                     }
                 }

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -542,14 +542,15 @@ fn get_fields_of_struct(input: syn::DeriveInput) -> Vec<(syn::Ident, syn::Type, 
         }
     }
 
-    named_fields
+    let named_fields_with_attrs = named_fields
         .into_iter()
         .enumerate()
         .map(|(i, f)| {
             let attr = &delta_user_col_tys[i];
             (f.ident.unwrap(), f.ty, attr.clone())
         })
-        .collect::<Vec<_>>() // (ident, ty, delta_bit_width)
+        .collect::<Vec<_>>();
+    named_fields_with_attrs
 }
 
 ///


### PR DESCRIPTION
### Summary
* The handling of the one sample of the i64 delta case has been implemented.
* This change enhances the robustness of our compression algorithm and ensures that it can handle a wider range of cases.
* Updated and added unit tests.
