### PR TITLE
Allow decompression of payloads with 0 or 1 rows

### DIFF
--- a/tsz-compress/src/v2/consts.rs
+++ b/tsz-compress/src/v2/consts.rs
@@ -1,5 +1,7 @@
 pub mod headers {
     pub const START_OF_COLUMN: u8 = 0b1001;
+    pub const FIRST_ROW: u8 = 0b0110;
+    pub const SECOND_ROW: u8 = FIRST_ROW;
 
     // DELTA ENCODING
     pub const THREE_BITS_TEN_SAMPLES: u8 = 0b1111;

--- a/tsz-compress/src/v2/decode.rs
+++ b/tsz-compress/src/v2/decode.rs
@@ -116,32 +116,32 @@ pub fn read_full_i8(buf: &[u8; 1]) -> i8 {
 /// and writes the decoded values to the Vec<i8>.
 ///
 pub fn decode_i8(iter: &mut HalfIter<'_>, output: &mut Vec<i8>) -> Result<(), CodingError> {
-    // No rows
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    // Check for 0 rows
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::FIRST_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Full 8 bit value
-    let buf = [(next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?];
+    let buf = [(iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+        | iter.next().ok_or(CodingError::NotEnoughBits)?];
     let value = read_full_i8(&buf);
     output.push(value);
 
     // One row
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::SECOND_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Delta encoded 16 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
     ];
@@ -299,18 +299,18 @@ pub fn decode_i8(iter: &mut HalfIter<'_>, output: &mut Vec<i8>) -> Result<(), Co
 /// and writes the decoded values to the Vec<i16>.
 ///
 pub fn decode_i16(iter: &mut HalfIter<'_>, output: &mut Vec<i16>) -> Result<(), CodingError> {
-    // No rows
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    // Check for 0 rows
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::FIRST_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Full 16 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
     ];
@@ -318,17 +318,17 @@ pub fn decode_i16(iter: &mut HalfIter<'_>, output: &mut Vec<i16>) -> Result<(), 
     output.push(value);
 
     // One row
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::SECOND_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Delta encoded 32 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
@@ -489,18 +489,18 @@ pub fn decode_i16(iter: &mut HalfIter<'_>, output: &mut Vec<i16>) -> Result<(), 
 /// and writes the decoded values to the Vec<i32>.
 ///
 pub fn decode_i32(iter: &mut HalfIter<'_>, output: &mut Vec<i32>) -> Result<(), CodingError> {
-    // No rows
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    // Check for 0 rows
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::FIRST_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Full 32 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
@@ -512,17 +512,17 @@ pub fn decode_i32(iter: &mut HalfIter<'_>, output: &mut Vec<i32>) -> Result<(), 
     output.push(value);
 
     // One row
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::SECOND_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Delta encoded 64 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
@@ -713,18 +713,18 @@ pub fn decode_i32(iter: &mut HalfIter<'_>, output: &mut Vec<i32>) -> Result<(), 
 /// and writes the decoded values to the Vec<i64>.
 ///
 pub fn decode_i64(iter: &mut HalfIter<'_>, output: &mut Vec<i64>) -> Result<(), CodingError> {
-    // No rows
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    // Check for 0 rows
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::FIRST_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Full 64 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
@@ -744,17 +744,17 @@ pub fn decode_i64(iter: &mut HalfIter<'_>, output: &mut Vec<i64>) -> Result<(), 
     output.push(value);
 
     // One row
-    let Some(next_upper) = iter.next() else {
-        return Ok(());
-    };
-    if next_upper == headers::START_OF_COLUMN {
-        // Start of column of next column
-        return Ok(());
+    match iter.next() {
+        None => return Ok(()),
+        Some(headers::START_OF_COLUMN) => return Ok(()),
+        Some(headers::SECOND_ROW) => {}
+        _ => return Err(CodingError::InvalidBits),
     }
 
     // Delta encoded 128 bit value
     let buf = [
-        (next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?,
+        (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
+            | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)
             | iter.next().ok_or(CodingError::NotEnoughBits)?,
         (iter.next().ok_or(CodingError::NotEnoughBits)? << 4)

--- a/tsz-compress/src/v2/decode.rs
+++ b/tsz-compress/src/v2/decode.rs
@@ -120,6 +120,10 @@ pub fn decode_i8(iter: &mut HalfIter<'_>, output: &mut Vec<i8>) -> Result<(), Co
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Full 8 bit value
     let buf = [(next_upper << 4) | iter.next().ok_or(CodingError::NotEnoughBits)?];
@@ -130,6 +134,10 @@ pub fn decode_i8(iter: &mut HalfIter<'_>, output: &mut Vec<i8>) -> Result<(), Co
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Delta encoded 16 bit value
     let buf = [
@@ -295,6 +303,10 @@ pub fn decode_i16(iter: &mut HalfIter<'_>, output: &mut Vec<i16>) -> Result<(), 
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Full 16 bit value
     let buf = [
@@ -309,6 +321,10 @@ pub fn decode_i16(iter: &mut HalfIter<'_>, output: &mut Vec<i16>) -> Result<(), 
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Delta encoded 32 bit value
     let buf = [
@@ -477,6 +493,10 @@ pub fn decode_i32(iter: &mut HalfIter<'_>, output: &mut Vec<i32>) -> Result<(), 
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Full 32 bit value
     let buf = [
@@ -495,6 +515,10 @@ pub fn decode_i32(iter: &mut HalfIter<'_>, output: &mut Vec<i32>) -> Result<(), 
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Delta encoded 64 bit value
     let buf = [
@@ -693,6 +717,10 @@ pub fn decode_i64(iter: &mut HalfIter<'_>, output: &mut Vec<i64>) -> Result<(), 
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Full 64 bit value
     let buf = [
@@ -719,6 +747,10 @@ pub fn decode_i64(iter: &mut HalfIter<'_>, output: &mut Vec<i64>) -> Result<(), 
     let Some(next_upper) = iter.next() else {
         return Ok(());
     };
+    if next_upper == headers::START_OF_COLUMN {
+        // Start of column of next column
+        return Ok(());
+    }
 
     // Delta encoded 128 bit value
     let buf = [

--- a/tsz-compress/tests/compress-v2.rs
+++ b/tsz-compress/tests/compress-v2.rs
@@ -343,6 +343,8 @@ mod tests {
         let result = decompressor.decompress(&bytes);
 
         // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
     }
 
     #[test]

--- a/tsz-compress/tests/compress-v2.rs
+++ b/tsz-compress/tests/compress-v2.rs
@@ -11,6 +11,340 @@ mod tests {
     use super::*;
     use rand::Rng;
 
+    // Tests for 0 rows compressed and decompressed
+    #[test]
+    fn test_macro_compress_i8_zero_rows() {
+        // Test with delta within i8 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i8,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 0;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i16_zero_rows() {
+        // Test with delta within i16 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i16,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 0;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i32_zero_rows() {
+        // Test with delta within i32 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 0;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i64_zero_rows() {
+        // Test with delta within i64 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i64,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 0;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+    }
+
+    // Tests for 1 row compressed and decompressed
+    #[test]
+    fn test_macro_compress_i8_one_rows() {
+        // Test with delta within i8 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i8,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 1;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i16_one_row() {
+        // Test with delta within i16 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i16,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 1;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i32_one_row() {
+        // Test with delta within i32 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i32,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 1;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+        assert_eq!(result.unwrap(), ());
+        assert_eq!(decompressor.col_a(), vec![row.a; N]);
+    }
+
+    #[test]
+    fn test_macro_compress_i64_one_row() {
+        // Test with delta within i64 range
+        mod row {
+            use tsz_compress::prelude::*;
+            #[derive(Debug, Copy, Clone, CompressV2, DecompressV2)]
+            pub struct TestRow {
+                pub a: i64,
+            }
+
+            pub use compress::TestRowCompressorImpl;
+            pub use decompress::TestRowDecompressorImpl;
+        }
+
+        use row::*;
+        const N: usize = 1;
+
+        // Test 10 samples (size of queue)
+        let row = TestRow { a: 1 };
+
+        // Initialize the compressor
+        let mut compressor = TestRowCompressorImpl::new(128);
+
+        // Compress row
+        for _ in 0..N {
+            compressor.compress(row);
+        }
+
+        // Finalize the compression
+        let bytes = compressor.finish();
+
+        // Initialize the decompressor
+        let mut decompressor = TestRowDecompressorImpl::new();
+
+        // Decompress the bit buffer
+        let result = decompressor.decompress(&bytes);
+
+        // Assert that the decompressed data matches the original
+    }
+
     #[test]
     fn test_macro_compress_sanity_i8_bit_width_values1() {
         mod row {

--- a/tsz-macro/src/lib.rs
+++ b/tsz-macro/src/lib.rs
@@ -860,10 +860,12 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                             #(
                                 if let Some(outbuf) = self.#col_delta_buf_idents.as_mut() {
                                     outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::START_OF_COLUMN));
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::FIRST_ROW));
                                     #write_first(outbuf, row.#col_idents);
                                 }
                                 if let Some(outbuf) = self.#col_delta_delta_buf_idents.as_mut() {
                                     outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::START_OF_COLUMN));
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::FIRST_ROW));
                                     #write_first(outbuf, row.#col_idents);
                                 }
                                 self.#prev_double_col_idents = row.#col_idents as #double_col_tys;
@@ -876,9 +878,11 @@ pub fn derive_compressv2(tokens: TokenStream) -> TokenStream {
                                 let col = row.#col_idents as #double_col_tys;
                                 let delta = col - self.#prev_double_col_idents;
                                 if let Some(outbuf) = self.#col_delta_buf_idents.as_mut() {
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::SECOND_ROW));
                                     #write_second(outbuf, delta);
                                 }
                                 if let Some(outbuf) = self.#col_delta_delta_buf_idents.as_mut() {
+                                    outbuf.push(::tsz_compress::prelude::halfvec::HalfWord::Half(::tsz_compress::prelude::consts::headers::SECOND_ROW));
                                     #write_second(outbuf, delta);
                                 }
 


### PR DESCRIPTION
This adds a nibble preceding the first row (delta) and second row (delta). The nibble is used to check if the column has 0 or 1 rows.

This will make v1.1.2 incompatible with v1.1.0 and v1.1.1.