### PR TITLE
Add thin-vec feature to compress directly into a ThinVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
+name = "thin-vec"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
+
+[[package]]
 name = "thiserror"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1864,7 @@ dependencies = [
  "bitvec",
  "num-traits",
  "rand",
+ "thin-vec",
  "tsz-macro",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-bench"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "criterion",
  "lz4_flex",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-compress"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "bitvec",
  "num-traits",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-macro"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "itertools 0.12.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ opt-level = 3
 debug = true
 
 [workspace.package]
-version = "1.1.5"
+version = "1.1.6"
 
 [workspace.dependencies]
-tsz-macro = { version = "1.1.5", path = "tsz-macro" }
-tsz-compress = { version = "1.1.5", path = "tsz-compress" }
+tsz-macro = { version = "1.1.6", path = "tsz-macro" }
+tsz-compress = { version = "1.1.6", path = "tsz-compress" }

--- a/tsz-compress/Cargo.toml
+++ b/tsz-compress/Cargo.toml
@@ -12,8 +12,7 @@ readme = "README.md"
 version = { workspace = true }
 
 [features]
-# default = []
-default = ["thin-vec"]
+default = []
 std = []
 thin-vec = ["dep:thin-vec", "tsz-macro/thin-vec"]
 

--- a/tsz-compress/Cargo.toml
+++ b/tsz-compress/Cargo.toml
@@ -12,8 +12,10 @@ readme = "README.md"
 version = { workspace = true }
 
 [features]
-default = []
+# default = []
+default = ["thin-vec"]
 std = []
+thin-vec = ["dep:thin-vec", "tsz-macro/thin-vec"]
 
 [lib]
 crate-type = ["rlib"]
@@ -21,6 +23,7 @@ crate-type = ["rlib"]
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 num-traits = { version = "0.2.17", default-features = false }
+thin-vec = { version = "0.2.13", default-features = false, optional = true }
 tsz-macro = { workspace = true }
 
 [dev-dependencies]

--- a/tsz-compress/src/v2/mod.rs
+++ b/tsz-compress/src/v2/mod.rs
@@ -98,6 +98,23 @@ pub trait TszCompressV2 {
         self.finish_into(&mut bytes);
         bytes
     }
+
+    ///
+    /// Consumes the compressor state the same was as `finish_into`, but
+    /// does so directly into a ThinVec
+    ///
+    #[cfg(feature = "thin-vec")]
+    fn finish_into_thin(&mut self, output_bytes: &mut ::thin_vec::ThinVec<u8>);
+
+    ///
+    /// Convenience method to call `finish_into_thin`
+    ///
+    #[cfg(feature = "thin-vec")]
+    fn finish_thin(&mut self) -> ::thin_vec::ThinVec<u8> {
+        let mut bytes = ::thin_vec::ThinVec::new();
+        self.finish_into_thin(&mut bytes);
+        bytes
+    }
 }
 
 ///

--- a/tsz-macro/Cargo.toml
+++ b/tsz-macro/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["time-series", "delta", "compression", "Gorilla", "serde"]
 readme = "README.md"
 version = { workspace = true }
 
+[features]
+default = []
+thin-vec = []
+
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
This reduces overhead of compressing into a Vec and copying into a ThinVec by supporting directly writing to a ThinVec.

Note this may be slower than the write to Vec following by an into ThinVec due to the writing of a ThinVec requiring a length check on the push despite the known reserved capacity